### PR TITLE
Fix minor typos

### DIFF
--- a/src/mqt/predictor/rl/actions.py
+++ b/src/mqt/predictor/rl/actions.py
@@ -6,7 +6,7 @@
 #
 # Licensed under the MIT License
 
-"""This modules provides the actions that can be used in the reinforcement learning environment."""
+"""This module provides the actions that can be used in the reinforcement learning environment."""
 
 from __future__ import annotations
 

--- a/src/mqt/predictor/rl/parsing.py
+++ b/src/mqt/predictor/rl/parsing.py
@@ -46,7 +46,7 @@ class PreProcessTKETRoutingAfterQiskitLayout:
                                           0  1  2
 
         Applying the trivial layout, we get the same qubit order as in the original circuit and can be respectively
-        routed. This results int:
+        routed. This results in:
                 ┌───┐           ░       ┌─┐
            q_0: ┤ H ├──■────────░───────┤M├
                 └───┘┌─┴─┐      ░    ┌─┐└╥┘
@@ -62,7 +62,7 @@ class PreProcessTKETRoutingAfterQiskitLayout:
                                    0  1  2
 
 
-        If we would not apply the trivial layout, no layout would be considered resulting, e.g., in the followiong circuit:
+        If we would not apply the trivial layout, no layout would be considered resulting, e.g., in the following circuit:
                  ┌───┐         ░    ┌─┐
        q_0: ─────┤ X ├─────■───░────┤M├───
             ┌───┐└─┬─┘   ┌─┴─┐ ░ ┌─┐└╥┘


### PR DESCRIPTION
<!--- This file has been generated from an external template. Please do not modify it directly. -->
<!--- Changes should be contributed to https://github.com/munich-quantum-toolkit/templates. -->

## Description
Fix minor typos
- This **modules** -> This **module**
- This results **int** -> This results **in**
- followiong -> following