### PR TITLE
✨ Add v3 MDP strategy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,15 +87,15 @@ for previous changelogs._
 
 <!-- PR links -->
 
-[#755]: https://github.com/munich-quantum-toolkit/predictor/pull/755
 [#773]: https://github.com/munich-quantum-toolkit/predictor/pull/771
 [#769]: https://github.com/munich-quantum-toolkit/predictor/pull/769
-[#697]: https://github.com/munich-quantum-toolkit/predictor/pull/697
+[#755]: https://github.com/munich-quantum-toolkit/predictor/pull/755
 [#731]: https://github.com/munich-quantum-toolkit/predictor/pull/731
 [#714]: https://github.com/munich-quantum-toolkit/predictor/pull/714
+[#697]: https://github.com/munich-quantum-toolkit/predictor/pull/697
 [#680]: https://github.com/munich-quantum-toolkit/predictor/pull/680
-[#677]: https://github.com/munich-quantum-toolkit/predictor/pull/677
 [#679]: https://github.com/munich-quantum-toolkit/predictor/pull/679
+[#677]: https://github.com/munich-quantum-toolkit/predictor/pull/677
 [#572]: https://github.com/munich-quantum-toolkit/predictor/pull/572
 [#489]: https://github.com/munich-quantum-toolkit/predictor/pull/489
 [#488]: https://github.com/munich-quantum-toolkit/predictor/pull/488

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ releases may include breaking changes.
 
 ### Changed
 
+- ✨ Add selectable `v2` and `v3` RL MDP strategies, make `v3` the default, and
+  use the selected strategy in compilation traces and model artifact names
+  ([#755]) ([**@flowerthrower**])
 - ✨ Replace composite BQSKit compilation actions with atomic passes ([#731])
   ([**@flowerthrower**])
 
@@ -77,6 +80,7 @@ for previous changelogs._
 
 <!-- PR links -->
 
+[#755]: https://github.com/munich-quantum-toolkit/predictor/pull/755
 [#697]: https://github.com/munich-quantum-toolkit/predictor/pull/697
 [#731]: https://github.com/munich-quantum-toolkit/predictor/pull/731
 [#714]: https://github.com/munich-quantum-toolkit/predictor/pull/714

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -36,9 +36,10 @@ for details about the individual passes.
 default. To retain the original MQT Predictor behavior, pass `mdp="v2"`
 explicitly.
 
-All existing RL models must be retrained for this release, including models used
-with `mdp="v2"`. Model artifact names now include the selected policy as
-`model_<figure_of_merit>_<device>_<mdp>`.
+Existing models trained with the previous MQT Predictor strategy can be reused
+with the `v2` policy. Copy or rename `model_<figure_of_merit>_<device>.zip` to
+`model_<figure_of_merit>_<device>_v2.zip`, then pass `mdp="v2"` to `Predictor`
+or `rl_compile`. Models for the new default `v3` policy must be retrained.
 
 ## [2.4.0]
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -30,6 +30,11 @@ how RL actions are used and the
 [BQSKit pass documentation](https://bqskit.readthedocs.io/en/latest/source/passes.html)
 for details about the individual passes.
 
+### Default RL MDP strategy
+
+`PredictorEnv` now uses the `v3` MDP strategy by default. To retain the original
+MQT Predictor behavior, pass `mdp="v2"` explicitly.
+
 ## [2.4.0]
 
 ### Trained RL model names

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -36,9 +36,9 @@ for details about the individual passes.
 default. To retain the original MQT Predictor behavior, pass `mdp="v2"`
 explicitly.
 
-Models trained with `mdp="v2"` must be retrained before use with `mdp="v3"`
-because the valid-action set and transition dynamics differ. Existing models can
-continue to use the original behavior with `mdp="v2"`.
+All existing RL models must be retrained for this release, including models used
+with `mdp="v2"`. Model artifact names now include the selected policy as
+`model_<figure_of_merit>_<device>_<mdp>`.
 
 ## [2.4.0]
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -32,8 +32,13 @@ for details about the individual passes.
 
 ### Default RL MDP strategy
 
-`PredictorEnv` now uses the `v3` MDP strategy by default. To retain the original
-MQT Predictor behavior, pass `mdp="v2"` explicitly.
+`PredictorEnv`, `Predictor`, and `rl_compile` now use the `v3` MDP strategy by
+default. To retain the original MQT Predictor behavior, pass `mdp="v2"`
+explicitly.
+
+Models trained with `mdp="v2"` must be retrained before use with `mdp="v3"`
+because the valid-action set and transition dynamics differ. Existing models can
+continue to use the original behavior with `mdp="v2"`.
 
 ## [2.4.0]
 

--- a/docs/compilation.md
+++ b/docs/compilation.md
@@ -47,13 +47,12 @@ targeted device.
 
 ## MDP Strategies
 
-The reinforcement learning environment supports three MDP strategies:
+The reinforcement learning environment supports two MDP strategies:
 
 - `v2` is the original MQT Predictor strategy.
-- `v3` is the default. It uses the flexible strategy before layout and restricts
+- `v3` is the default. It uses a permissive strategy before layout and restricts
   later optimization to actions that preserve the established compilation
   structure.
-- `flexible` provides the greatest freedom among all structurally valid actions.
 
 Select a strategy with the `mdp` parameter of `PredictorEnv`, `Predictor`, or
 `rl_compile`, for example `mdp="v2"`.

--- a/docs/compilation.md
+++ b/docs/compilation.md
@@ -54,3 +54,6 @@ The reinforcement learning environment supports three MDP strategies:
   later optimization to actions that preserve the established compilation
   structure.
 - `flexible` provides the greatest freedom among all structurally valid actions.
+
+Select a strategy with the `mdp` parameter of `PredictorEnv`, `Predictor`, or
+`rl_compile`, for example `mdp="v2"`.

--- a/docs/compilation.md
+++ b/docs/compilation.md
@@ -44,3 +44,13 @@ compiler:
 
 The trained model can then be used to compile any quantum circuit for the
 targeted device.
+
+## MDP Strategies
+
+The reinforcement learning environment supports three MDP strategies:
+
+- `v3` is the default. It uses the flexible strategy before layout and restricts
+  later optimization to actions that preserve the established compilation
+  structure.
+- `v2` is the original MQT Predictor strategy.
+- `flexible` provides the greatest freedom among all structurally valid actions.

--- a/docs/compilation.md
+++ b/docs/compilation.md
@@ -49,8 +49,8 @@ targeted device.
 
 The reinforcement learning environment supports three MDP strategies:
 
+- `v2` is the original MQT Predictor strategy.
 - `v3` is the default. It uses the flexible strategy before layout and restricts
   later optimization to actions that preserve the established compilation
   structure.
-- `v2` is the original MQT Predictor strategy.
 - `flexible` provides the greatest freedom among all structurally valid actions.

--- a/docs/tracing.md
+++ b/docs/tracing.md
@@ -50,7 +50,7 @@ The root of the JSON file provides general context about the compilation run:
 - **`figure_of_merit`**: The primary metric the RL agent optimized for (e.g.,
   `expected_fidelity`).
 - **`mdp_policy`**: The Markov Decision Process (MDP) transition policy used
-  during the episode.
+  during the episode: `v2`, `v3`, or `flexible`.
 - **`schema_version`**: The version of the JSON schema (useful for ensuring
   compatibility with visualization tools like MQT FlowViz).
 - **`timestamp`**: The exact Unix timestamp when the compilation started.

--- a/docs/tracing.md
+++ b/docs/tracing.md
@@ -50,7 +50,7 @@ The root of the JSON file provides general context about the compilation run:
 - **`figure_of_merit`**: The primary metric the RL agent optimized for (e.g.,
   `expected_fidelity`).
 - **`mdp_policy`**: The Markov Decision Process (MDP) transition policy used
-  during the episode: `v2`, `v3`, or `flexible`.
+  during the episode: `v2` or `v3`.
 - **`schema_version`**: The version of the JSON schema (useful for ensuring
   compatibility with visualization tools like MQT FlowViz).
 - **`timestamp`**: The exact Unix timestamp when the compilation started.

--- a/src/mqt/predictor/rl/predictor.py
+++ b/src/mqt/predictor/rl/predictor.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 
 import logging
 from pathlib import Path
-from typing import TYPE_CHECKING, Literal
+from typing import TYPE_CHECKING
 
 from sb3_contrib import MaskablePPO
 from sb3_contrib.common.maskable.policies import MaskableMultiInputActorCriticPolicy
@@ -20,7 +20,7 @@ from sb3_contrib.common.maskable.utils import get_action_masks
 from stable_baselines3.common.utils import set_random_seed
 
 from mqt.predictor.rl.helper import get_path_trained_model, logger
-from mqt.predictor.rl.predictorenv import PredictorEnv
+from mqt.predictor.rl.predictorenv import MDPPolicy, PredictorEnv
 
 if TYPE_CHECKING:
     from qiskit import QuantumCircuit
@@ -40,7 +40,7 @@ class Predictor:
         logger_level: int = logging.INFO,
         max_steps: int | None = None,
         tracer_output_path: str | Path | None = None,
-        mdp: Literal["v2", "v3", "flexible"] = "v3",
+        mdp: MDPPolicy = "v3",
     ) -> None:
         """Initializes the Predictor object.
 
@@ -192,7 +192,7 @@ def rl_compile(
     figure_of_merit: figure_of_merit | None = "expected_fidelity",
     predictor_singleton: Predictor | None = None,
     tracer_output_path: str | Path | None = None,
-    mdp: Literal["v2", "v3", "flexible"] = "v3",
+    mdp: MDPPolicy = "v3",
 ) -> tuple[QuantumCircuit, list[str]]:
     """Compiles a given quantum circuit to a device optimizing for the given figure of merit.
 
@@ -204,7 +204,8 @@ def rl_compile(
         tracer_output_path: If provided, enables compiler tracing and exports the JSON log to the specified path.
         mdp: The MDP transition policy used when constructing a predictor. ``v2``
             is the original strategy, ``v3`` is the default, and ``flexible``
-            provides the greatest freedom.
+            provides the greatest freedom. When ``predictor_singleton`` is
+            provided, its configured policy is used instead.
 
     Returns:
         A tuple containing the compiled quantum circuit and the compilation information. If compilation fails, False is returned.

--- a/src/mqt/predictor/rl/predictor.py
+++ b/src/mqt/predictor/rl/predictor.py
@@ -51,8 +51,8 @@ class Predictor:
             logger_level: The logger level. Defaults to logging.INFO.
             max_steps: The maximum number of actions per episode. Defaults to None, which means no step limit is enforced.
             tracer_output_path: Path to export the compilation trace JSON. Defaults to None.
-            mdp: The MDP transition policy. ``v2`` is the original strategy,
-                ``v3`` is the default, and ``flexible`` provides the greatest freedom.
+            mdp: The MDP transition policy. ``v2`` is the original strategy and
+                ``v3`` is the default.
         """
         logger.setLevel(logger_level)
 
@@ -204,9 +204,8 @@ def rl_compile(
         predictor_singleton: A predictor object that is used for compilation to reduce compilation time when compiling multiple quantum circuits. If None, a new predictor object is created. Defaults to None.
         tracer_output_path: If provided, enables compiler tracing and exports the JSON log to the specified path.
         mdp: The MDP transition policy used when constructing a predictor. ``v2``
-            is the original strategy, ``v3`` is the default, and ``flexible``
-            provides the greatest freedom. When ``predictor_singleton`` is
-            provided, its configured policy is used instead.
+            is the original strategy and ``v3`` is the default. When
+            ``predictor_singleton`` is provided, its configured policy is used instead.
 
     Returns:
         A tuple containing the compiled quantum circuit and the compilation information. If compilation fails, False is returned.

--- a/src/mqt/predictor/rl/predictor.py
+++ b/src/mqt/predictor/rl/predictor.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 
 import logging
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Literal
 
 from sb3_contrib import MaskablePPO
 from sb3_contrib.common.maskable.policies import MaskableMultiInputActorCriticPolicy
@@ -40,6 +40,7 @@ class Predictor:
         logger_level: int = logging.INFO,
         max_steps: int | None = None,
         tracer_output_path: str | Path | None = None,
+        mdp: Literal["v2", "v3", "flexible"] = "v3",
     ) -> None:
         """Initializes the Predictor object.
 
@@ -50,6 +51,8 @@ class Predictor:
             logger_level: The logger level. Defaults to logging.INFO.
             max_steps: The maximum number of actions per episode. Defaults to None, which means no step limit is enforced.
             tracer_output_path: Path to export the compilation trace JSON. Defaults to None.
+            mdp: The MDP transition policy. ``v2`` is the original strategy,
+                ``v3`` is the default, and ``flexible`` provides the greatest freedom.
         """
         logger.setLevel(logger_level)
 
@@ -59,6 +62,7 @@ class Predictor:
             path_training_circuits=path_training_circuits,
             max_steps=max_steps,
             tracer_output_path=tracer_output_path,
+            mdp=mdp,
         )
         self.device_name = device.description
         self.figure_of_merit = figure_of_merit
@@ -188,6 +192,7 @@ def rl_compile(
     figure_of_merit: figure_of_merit | None = "expected_fidelity",
     predictor_singleton: Predictor | None = None,
     tracer_output_path: str | Path | None = None,
+    mdp: Literal["v2", "v3", "flexible"] = "v3",
 ) -> tuple[QuantumCircuit, list[str]]:
     """Compiles a given quantum circuit to a device optimizing for the given figure of merit.
 
@@ -197,6 +202,9 @@ def rl_compile(
         figure_of_merit: The figure of merit to be used for compilation. Defaults to "expected_fidelity".
         predictor_singleton: A predictor object that is used for compilation to reduce compilation time when compiling multiple quantum circuits. If None, a new predictor object is created. Defaults to None.
         tracer_output_path: If provided, enables compiler tracing and exports the JSON log to the specified path.
+        mdp: The MDP transition policy used when constructing a predictor. ``v2``
+            is the original strategy, ``v3`` is the default, and ``flexible``
+            provides the greatest freedom.
 
     Returns:
         A tuple containing the compiled quantum circuit and the compilation information. If compilation fails, False is returned.
@@ -211,7 +219,12 @@ def rl_compile(
         if device is None:
             msg = "device must not be None if predictor_singleton is None."
             raise ValueError(msg)
-        predictor = Predictor(figure_of_merit=figure_of_merit, device=device, tracer_output_path=tracer_output_path)
+        predictor = Predictor(
+            figure_of_merit=figure_of_merit,
+            device=device,
+            tracer_output_path=tracer_output_path,
+            mdp=mdp,
+        )
         return predictor.compile_as_predicted(qc)
 
     return predictor_singleton.compile_as_predicted(qc, tracer_output_path=tracer_output_path)

--- a/src/mqt/predictor/rl/predictor.py
+++ b/src/mqt/predictor/rl/predictor.py
@@ -66,6 +66,7 @@ class Predictor:
         )
         self.device_name = device.description
         self.figure_of_merit = figure_of_merit
+        self.model_name = f"model_{self.figure_of_merit}_{self.device_name}_{mdp}"
 
     def compile_as_predicted(
         self,
@@ -91,7 +92,7 @@ class Predictor:
             self.env.tracer_output_path = tracer_output_path
 
         try:
-            trained_rl_model = load_model("model_" + self.figure_of_merit + "_" + self.device_name)
+            trained_rl_model = load_model(self.model_name)
 
             obs, _ = self.env.reset(qc, seed=0)
 
@@ -152,7 +153,7 @@ class Predictor:
             MaskableMultiInputActorCriticPolicy,
             self.env,
             verbose=verbose,
-            tensorboard_log="./model_" + self.figure_of_merit + "_" + self.device_name,
+            tensorboard_log=f"./{self.model_name}",
             gamma=0.98,
             n_steps=n_steps,
             batch_size=batch_size,
@@ -162,7 +163,7 @@ class Predictor:
         # Training Loop: In each iteration, the agent collects n_steps steps (rollout),
         # updates the policy for n_epochs, and then repeats the process until total_timesteps steps have been taken.
         model.learn(total_timesteps=timesteps, progress_bar=progress_bar)
-        model.save(get_path_trained_model() / ("model_" + self.figure_of_merit + "_" + self.device_name))
+        model.save(get_path_trained_model() / self.model_name)
 
 
 def load_model(model_name: str) -> MaskablePPO:

--- a/src/mqt/predictor/rl/predictorenv.py
+++ b/src/mqt/predictor/rl/predictorenv.py
@@ -79,7 +79,11 @@ class PredictorEnv(Env):
                 valid actions.
 
         Raises:
-            ValueError: If the reward function is "estimated_success_probability" and no calibration data is available for the device or if the reward function is "estimated_hellinger_distance" and no trained model is available for the device.
+            ValueError: If ``mdp`` is unsupported, if the reward function is
+                "estimated_success_probability" and no calibration data is available
+                for the device, or if the reward function is
+                "estimated_hellinger_distance" and no trained model is available for
+                the device.
         """
         logger.info("Init env: " + reward_function)
 

--- a/src/mqt/predictor/rl/predictorenv.py
+++ b/src/mqt/predictor/rl/predictorenv.py
@@ -72,9 +72,9 @@ class PredictorEnv(Env):
             path_training_circuits: The path to the training circuits folder. Defaults to None, which uses the default path.
             max_steps: The maximum number of actions per episode. Defaults to None, which means no step limit is enforced.
             tracer_output_path: Path to export the compilation trace JSON. Defaults to None.
-            mdp: The MDP transition policy. ``v3`` is the default and is flexible
-                before layout while preserving the established compilation structure
-                afterwards. ``v2`` is the original MQT Predictor strategy.
+            mdp: The MDP transition policy. ``v2`` is the original MQT Predictor
+                strategy. ``v3`` is the default and is flexible before layout while
+                preserving the established compilation structure afterwards.
                 ``flexible`` provides the greatest freedom among all structurally
                 valid actions.
 
@@ -417,15 +417,7 @@ class PredictorEnv(Env):
 
         # Reset caches and evaluate initial baseline state
         self._current_foms = {}
-        self._current_synthesized = self.is_circuit_synthesized(self.state)
-        self._current_laid_out = self.is_circuit_laid_out(self.state, self.layout) if self.layout else False
-        self._current_routed = (
-            self.is_circuit_routed(self.state, CouplingMap(self.device.build_coupling_map()))
-            if self._current_laid_out
-            else False
-        )
-
-        self.valid_actions = self.actions_synthesis_indices + self.actions_opt_indices
+        self.valid_actions = self.determine_valid_actions_for_state()
 
         self.error_occurred = False
 

--- a/src/mqt/predictor/rl/predictorenv.py
+++ b/src/mqt/predictor/rl/predictorenv.py
@@ -15,7 +15,7 @@ import re
 import time
 import warnings
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Literal
+from typing import TYPE_CHECKING, Any, Literal, get_args
 
 if TYPE_CHECKING:
     from gymnasium.spaces import Space
@@ -51,6 +51,9 @@ from mqt.predictor.rl.tracer import CompilationTracer, FigureOfMeritMetric, Figu
 
 logger = logging.getLogger("mqt-predictor")
 
+MDPPolicy = Literal["v2", "v3", "flexible"]
+MDP_POLICIES: frozenset[str] = frozenset(get_args(MDPPolicy))
+
 
 class PredictorEnv(Env):
     """Predictor environment for reinforcement learning."""
@@ -62,7 +65,7 @@ class PredictorEnv(Env):
         path_training_circuits: Path | None = None,
         max_steps: int | None = None,
         tracer_output_path: str | Path | None = None,
-        mdp: Literal["v2", "v3", "flexible"] = "v3",
+        mdp: MDPPolicy = "v3",
     ) -> None:
         """Initializes the PredictorEnv object.
 
@@ -85,9 +88,9 @@ class PredictorEnv(Env):
                 "estimated_hellinger_distance" and no trained model is available for
                 the device.
         """
-        logger.info("Init env: " + reward_function)
+        logger.info("Init env: %s", reward_function)
 
-        if mdp not in {"v2", "v3", "flexible"}:
+        if mdp not in MDP_POLICIES:
             msg = f"Unsupported MDP policy: {mdp}."
             raise ValueError(msg)
 
@@ -689,7 +692,7 @@ class PredictorEnv(Env):
                 actions.extend(self.actions_structure_preserving_indices)
                 actions.extend(self.actions_final_optimization_indices)
 
-        else:  # flexible
+        elif self.mdp == "flexible":
             if not synthesized and not laid_out:
                 actions.extend(self.actions_synthesis_indices)
                 actions.extend(self.actions_mapping_indices)
@@ -712,5 +715,6 @@ class PredictorEnv(Env):
             else:
                 actions.append(self.action_terminate_index)
                 actions.extend(self.actions_opt_indices)
+                actions.extend(self.actions_final_optimization_indices)
 
         return actions

--- a/src/mqt/predictor/rl/predictorenv.py
+++ b/src/mqt/predictor/rl/predictorenv.py
@@ -73,9 +73,9 @@ class PredictorEnv(Env):
             max_steps: The maximum number of actions per episode. Defaults to None, which means no step limit is enforced.
             tracer_output_path: Path to export the compilation trace JSON. Defaults to None.
             mdp: The MDP transition policy. ``paper`` follows the original linear
-                compilation flow, ``flexible`` permits all pre-routing actions,
-                ``thesis`` preserves the compilation structure after layout, and
-                ``hybrid`` is flexible until layout has been established.
+                compilation flow. ``flexible`` permits optimization throughout,
+                ``thesis`` limits post-layout changes to structure-preserving passes,
+                and ``hybrid`` combines flexible early stages with that restriction.
 
         Raises:
             ValueError: If the reward function is "estimated_success_probability" and no calibration data is available for the device or if the reward function is "estimated_hellinger_distance" and no trained model is available for the device.
@@ -97,8 +97,6 @@ class PredictorEnv(Env):
         self.actions_mapping_indices = []
         self.actions_opt_indices = []
         self.actions_final_optimization_indices = []
-        self.actions_layout_preserving_indices = []
-        self.actions_routing_preserving_indices = []
         self.actions_structure_preserving_indices = []
         self.used_actions: list[str] = []
         self.device = device
@@ -131,10 +129,6 @@ class PredictorEnv(Env):
         for elem in action_dict[PassType.OPT]:
             self.action_set[index] = elem
             self.actions_opt_indices.append(index)
-            if elem.preserves_layout:
-                self.actions_layout_preserving_indices.append(index)
-            if elem.preserves_layout and elem.preserves_routing:
-                self.actions_routing_preserving_indices.append(index)
             if elem.preserves_layout and elem.preserves_routing and elem.preserves_synthesis:
                 self.actions_structure_preserving_indices.append(index)
             index += 1
@@ -643,36 +637,74 @@ class PredictorEnv(Env):
         actions = []
 
         if self.mdp == "flexible":
-            if not laid_out:
-                actions.extend(self.actions_synthesis_indices)
-                actions.extend(self.actions_mapping_indices)
-                actions.extend(self.actions_layout_indices)
-            elif not routed:
-                actions.extend(self.actions_synthesis_indices)
-                actions.extend(self.actions_routing_indices)
-            else:
-                actions.extend(self.actions_synthesis_indices)
-            actions.extend(self.actions_opt_indices)
-            if synthesized and laid_out and routed:
-                actions.append(self.action_terminate_index)
-
-        elif self.mdp == "hybrid" or self.mdp == "thesis":
-            if not laid_out:
+            if not synthesized and not laid_out:
                 actions.extend(self.actions_synthesis_indices)
                 actions.extend(self.actions_mapping_indices)
                 actions.extend(self.actions_layout_indices)
                 actions.extend(self.actions_opt_indices)
-            elif not routed:
+            elif synthesized and not laid_out:
+                actions.extend(self.actions_mapping_indices)
+                actions.extend(self.actions_layout_indices)
+                actions.extend(self.actions_opt_indices)
+            elif not synthesized and laid_out and not routed:
                 actions.extend(self.actions_synthesis_indices)
                 actions.extend(self.actions_routing_indices)
-                actions.extend(self.actions_layout_preserving_indices)
-            else:
+                actions.extend(self.actions_opt_indices)
+            elif synthesized and laid_out and not routed:
+                actions.extend(self.actions_routing_indices)
+                actions.extend(self.actions_opt_indices)
+            elif not synthesized and laid_out and routed:
                 actions.extend(self.actions_synthesis_indices)
-                actions.extend(self.actions_routing_preserving_indices)
-                if synthesized:
-                    actions.extend(self.actions_structure_preserving_indices)
-                    actions.extend(self.actions_final_optimization_indices)
-                    actions.append(self.action_terminate_index)
+                actions.extend(self.actions_opt_indices)
+            else:
+                actions.append(self.action_terminate_index)
+                actions.extend(self.actions_opt_indices)
+
+        elif self.mdp == "hybrid":
+            if not synthesized and not laid_out:
+                actions.extend(self.actions_synthesis_indices)
+                actions.extend(self.actions_mapping_indices)
+                actions.extend(self.actions_layout_indices)
+                actions.extend(self.actions_opt_indices)
+            elif synthesized and not laid_out:
+                actions.extend(self.actions_mapping_indices)
+                actions.extend(self.actions_layout_indices)
+                actions.extend(self.actions_opt_indices)
+            elif not synthesized and laid_out and not routed:
+                actions.extend(self.actions_synthesis_indices)
+                actions.extend(self.actions_routing_indices)
+                actions.extend(self.actions_structure_preserving_indices)
+            elif synthesized and laid_out and not routed:
+                actions.extend(self.actions_routing_indices)
+                actions.extend(self.actions_structure_preserving_indices)
+            elif not synthesized and laid_out and routed:
+                actions.extend(self.actions_synthesis_indices)
+                actions.extend(self.actions_structure_preserving_indices)
+            else:
+                actions.append(self.action_terminate_index)
+                actions.extend(self.actions_structure_preserving_indices)
+                actions.extend(self.actions_final_optimization_indices)
+
+        elif self.mdp == "thesis":
+            if not synthesized and not laid_out:
+                actions.extend(self.actions_synthesis_indices)
+                actions.extend(self.actions_opt_indices)
+            elif synthesized and not laid_out:
+                actions.extend(self.actions_mapping_indices)
+                actions.extend(self.actions_layout_indices)
+                actions.extend(self.actions_opt_indices)
+            elif not synthesized and laid_out and not routed:
+                actions.extend(self.actions_synthesis_indices)
+                actions.extend(self.actions_structure_preserving_indices)
+            elif synthesized and laid_out and not routed:
+                actions.extend(self.actions_routing_indices)
+            elif not synthesized and laid_out and routed:
+                actions.extend(self.actions_synthesis_indices)
+                actions.extend(self.actions_structure_preserving_indices)
+            else:
+                actions.append(self.action_terminate_index)
+                actions.extend(self.actions_structure_preserving_indices)
+                actions.extend(self.actions_final_optimization_indices)
 
         else:
             if not synthesized and not laid_out and not routed:

--- a/src/mqt/predictor/rl/predictorenv.py
+++ b/src/mqt/predictor/rl/predictorenv.py
@@ -425,6 +425,15 @@ class PredictorEnv(Env):
         # Reset caches and evaluate initial baseline state
         self._current_foms = {}
         self.valid_actions = self.determine_valid_actions_for_state()
+        if self.mdp == "v2":
+            self.valid_actions = self.actions_synthesis_indices + self.actions_opt_indices
+        else:
+            self.valid_actions = (
+                self.actions_synthesis_indices
+                + self.actions_mapping_indices
+                + self.actions_layout_indices
+                + self.actions_opt_indices
+            )
 
         self.error_occurred = False
 

--- a/src/mqt/predictor/rl/predictorenv.py
+++ b/src/mqt/predictor/rl/predictorenv.py
@@ -51,7 +51,7 @@ from mqt.predictor.rl.tracer import CompilationTracer, FigureOfMeritMetric, Figu
 
 logger = logging.getLogger("mqt-predictor")
 
-MDPPolicy = Literal["v2", "v3", "flexible"]
+MDPPolicy = Literal["v2", "v3"]
 MDP_POLICIES: frozenset[str] = frozenset(get_args(MDPPolicy))
 
 
@@ -76,10 +76,8 @@ class PredictorEnv(Env):
             max_steps: The maximum number of actions per episode. Defaults to None, which means no step limit is enforced.
             tracer_output_path: Path to export the compilation trace JSON. Defaults to None.
             mdp: The MDP transition policy. ``v2`` is the original MQT Predictor
-                strategy. ``v3`` is the default and is flexible before layout while
+                strategy. ``v3`` is the default and is permissive before layout while
                 preserving the established compilation structure afterwards.
-                ``flexible`` provides the greatest freedom among all structurally
-                valid actions.
 
         Raises:
             ValueError: If ``mdp`` is unsupported, if the reward function is
@@ -677,38 +675,6 @@ class PredictorEnv(Env):
             *self.actions_final_optimization_indices,
         ]
 
-    def _valid_actions_flexible(self, synthesized: bool, laid_out: bool, routed: bool) -> list[int]:
-        """Return valid action indices for the flexible MDP policy."""
-        if not synthesized and not laid_out:
-            return [
-                *self.actions_synthesis_indices,
-                *self.actions_mapping_indices,
-                *self.actions_layout_indices,
-                *self.actions_opt_indices,
-            ]
-
-        if synthesized and not laid_out:
-            return [*self.actions_mapping_indices, *self.actions_layout_indices, *self.actions_opt_indices]
-
-        if not synthesized and laid_out and not routed:
-            return [
-                *self.actions_synthesis_indices,
-                *self.actions_routing_indices,
-                *self.actions_opt_indices,
-            ]
-
-        if synthesized and laid_out and not routed:
-            return [*self.actions_routing_indices, *self.actions_opt_indices]
-
-        if not synthesized and laid_out and routed:
-            return [*self.actions_synthesis_indices, *self.actions_opt_indices]
-
-        return [
-            self.action_terminate_index,
-            *self.actions_opt_indices,
-            *self.actions_final_optimization_indices,
-        ]
-
     def determine_valid_actions_for_state(self) -> list[int]:
         """Select structurally valid action indices for the current circuit state.
 
@@ -737,7 +703,4 @@ class PredictorEnv(Env):
         if self.mdp == "v2":
             return self._valid_actions_v2(synthesized, laid_out, routed)
 
-        if self.mdp == "v3":
-            return self._valid_actions_v3(synthesized, laid_out, routed)
-
-        return self._valid_actions_flexible(synthesized, laid_out, routed)
+        return self._valid_actions_v3(synthesized, laid_out, routed)

--- a/src/mqt/predictor/rl/predictorenv.py
+++ b/src/mqt/predictor/rl/predictorenv.py
@@ -618,6 +618,97 @@ class PredictorEnv(Env):
                     return False
         return True
 
+    def _valid_actions_v2(self, synthesized: bool, laid_out: bool, routed: bool) -> list[int]:
+        """Return valid action indices for the v2 MDP policy."""
+        # Initial state
+        if not synthesized and not laid_out and not routed:
+            return [*self.actions_synthesis_indices, *self.actions_opt_indices]
+
+        if synthesized and not laid_out and not routed:
+            return [*self.actions_mapping_indices, *self.actions_layout_indices, *self.actions_opt_indices]
+
+        # Not *depicted* in paper; necessary because optimization can destroy the native gate set
+        if not synthesized and laid_out and not routed:
+            return [*self.actions_synthesis_indices, *self.actions_routing_indices, *self.actions_opt_indices]
+
+        # Not *depicted* in paper; necessary because of layout-only passes
+        if synthesized and laid_out and not routed:
+            return [*self.actions_routing_indices]
+
+        # Not *depicted* in paper; necessary because routing can insert non-native SWAPs
+        if not synthesized and laid_out and routed:
+            return [*self.actions_synthesis_indices, *self.actions_opt_indices]
+
+        # Final state
+        if synthesized and laid_out and routed:
+            return [self.action_terminate_index, *self.actions_opt_indices]
+
+        return []
+
+    def _valid_actions_v3(self, synthesized: bool, laid_out: bool, routed: bool) -> list[int]:
+        """Return valid action indices for the v3 MDP policy."""
+        if not synthesized and not laid_out:
+            return [
+                *self.actions_synthesis_indices,
+                *self.actions_mapping_indices,
+                *self.actions_layout_indices,
+                *self.actions_opt_indices,
+            ]
+
+        if synthesized and not laid_out:
+            return [*self.actions_mapping_indices, *self.actions_layout_indices, *self.actions_opt_indices]
+
+        if not synthesized and laid_out and not routed:
+            return [
+                *self.actions_synthesis_indices,
+                *self.actions_routing_indices,
+                *self.actions_structure_preserving_indices,
+            ]
+
+        if synthesized and laid_out and not routed:
+            return [*self.actions_routing_indices, *self.actions_structure_preserving_indices]
+
+        if not synthesized and laid_out and routed:
+            return [*self.actions_synthesis_indices, *self.actions_structure_preserving_indices]
+
+        return [
+            self.action_terminate_index,
+            *self.actions_structure_preserving_indices,
+            *self.actions_final_optimization_indices,
+        ]
+
+    def _valid_actions_flexible(self, synthesized: bool, laid_out: bool, routed: bool) -> list[int]:
+        """Return valid action indices for the flexible MDP policy."""
+        if not synthesized and not laid_out:
+            return [
+                *self.actions_synthesis_indices,
+                *self.actions_mapping_indices,
+                *self.actions_layout_indices,
+                *self.actions_opt_indices,
+            ]
+
+        if synthesized and not laid_out:
+            return [*self.actions_mapping_indices, *self.actions_layout_indices, *self.actions_opt_indices]
+
+        if not synthesized and laid_out and not routed:
+            return [
+                *self.actions_synthesis_indices,
+                *self.actions_routing_indices,
+                *self.actions_opt_indices,
+            ]
+
+        if synthesized and laid_out and not routed:
+            return [*self.actions_routing_indices, *self.actions_opt_indices]
+
+        if not synthesized and laid_out and routed:
+            return [*self.actions_synthesis_indices, *self.actions_opt_indices]
+
+        return [
+            self.action_terminate_index,
+            *self.actions_opt_indices,
+            *self.actions_final_optimization_indices,
+        ]
+
     def determine_valid_actions_for_state(self) -> list[int]:
         """Select structurally valid action indices for the current circuit state.
 
@@ -643,87 +734,10 @@ class PredictorEnv(Env):
         laid_out = self._current_laid_out
         routed = self._current_routed
 
-        actions = []
-
         if self.mdp == "v2":
-            # Initial state
-            if not synthesized and not laid_out and not routed:
-                actions.extend(self.actions_synthesis_indices)
-                actions.extend(self.actions_opt_indices)
+            return self._valid_actions_v2(synthesized, laid_out, routed)
 
-            elif synthesized and not laid_out and not routed:
-                actions.extend(self.actions_mapping_indices)
-                actions.extend(self.actions_layout_indices)
-                actions.extend(self.actions_opt_indices)
+        if self.mdp == "v3":
+            return self._valid_actions_v3(synthesized, laid_out, routed)
 
-            # Not *depicted* in paper; necessary because optimization can destroy the native gate set
-            elif not synthesized and laid_out and not routed:
-                actions.extend(self.actions_synthesis_indices)
-                actions.extend(self.actions_routing_indices)
-                actions.extend(self.actions_opt_indices)
-
-            # Not *depicted* in paper; necessary because of layout-only passes
-            elif synthesized and laid_out and not routed:
-                actions.extend(self.actions_routing_indices)
-
-            # Not *depicted* in paper; necessary because routing can insert non-native SWAPs
-            elif not synthesized and laid_out and routed:
-                actions.extend(self.actions_synthesis_indices)
-                actions.extend(self.actions_opt_indices)
-
-            # Final state
-            elif synthesized and laid_out and routed:
-                actions.append(self.action_terminate_index)
-                actions.extend(self.actions_opt_indices)
-
-        elif self.mdp == "v3":
-            if not synthesized and not laid_out:
-                actions.extend(self.actions_synthesis_indices)
-                actions.extend(self.actions_mapping_indices)
-                actions.extend(self.actions_layout_indices)
-                actions.extend(self.actions_opt_indices)
-            elif synthesized and not laid_out:
-                actions.extend(self.actions_mapping_indices)
-                actions.extend(self.actions_layout_indices)
-                actions.extend(self.actions_opt_indices)
-            elif not synthesized and laid_out and not routed:
-                actions.extend(self.actions_synthesis_indices)
-                actions.extend(self.actions_routing_indices)
-                actions.extend(self.actions_structure_preserving_indices)
-            elif synthesized and laid_out and not routed:
-                actions.extend(self.actions_routing_indices)
-                actions.extend(self.actions_structure_preserving_indices)
-            elif not synthesized and laid_out and routed:
-                actions.extend(self.actions_synthesis_indices)
-                actions.extend(self.actions_structure_preserving_indices)
-            else:
-                actions.append(self.action_terminate_index)
-                actions.extend(self.actions_structure_preserving_indices)
-                actions.extend(self.actions_final_optimization_indices)
-
-        elif self.mdp == "flexible":
-            if not synthesized and not laid_out:
-                actions.extend(self.actions_synthesis_indices)
-                actions.extend(self.actions_mapping_indices)
-                actions.extend(self.actions_layout_indices)
-                actions.extend(self.actions_opt_indices)
-            elif synthesized and not laid_out:
-                actions.extend(self.actions_mapping_indices)
-                actions.extend(self.actions_layout_indices)
-                actions.extend(self.actions_opt_indices)
-            elif not synthesized and laid_out and not routed:
-                actions.extend(self.actions_synthesis_indices)
-                actions.extend(self.actions_routing_indices)
-                actions.extend(self.actions_opt_indices)
-            elif synthesized and laid_out and not routed:
-                actions.extend(self.actions_routing_indices)
-                actions.extend(self.actions_opt_indices)
-            elif not synthesized and laid_out and routed:
-                actions.extend(self.actions_synthesis_indices)
-                actions.extend(self.actions_opt_indices)
-            else:
-                actions.append(self.action_terminate_index)
-                actions.extend(self.actions_opt_indices)
-                actions.extend(self.actions_final_optimization_indices)
-
-        return actions
+        return self._valid_actions_flexible(synthesized, laid_out, routed)

--- a/src/mqt/predictor/rl/predictorenv.py
+++ b/src/mqt/predictor/rl/predictorenv.py
@@ -15,7 +15,7 @@ import re
 import time
 import warnings
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Literal
 
 if TYPE_CHECKING:
     from gymnasium.spaces import Space
@@ -62,7 +62,7 @@ class PredictorEnv(Env):
         path_training_circuits: Path | None = None,
         max_steps: int | None = None,
         tracer_output_path: str | Path | None = None,
-        mdp: str = "paper",
+        mdp: Literal["v2", "v3", "flexible"] = "v3",
     ) -> None:
         """Initializes the PredictorEnv object.
 
@@ -72,17 +72,18 @@ class PredictorEnv(Env):
             path_training_circuits: The path to the training circuits folder. Defaults to None, which uses the default path.
             max_steps: The maximum number of actions per episode. Defaults to None, which means no step limit is enforced.
             tracer_output_path: Path to export the compilation trace JSON. Defaults to None.
-            mdp: The MDP transition policy. ``paper`` follows the original linear
-                compilation flow. ``flexible`` permits optimization throughout,
-                ``thesis`` limits post-layout changes to structure-preserving passes,
-                and ``hybrid`` combines flexible early stages with that restriction.
+            mdp: The MDP transition policy. ``v3`` is the default and is flexible
+                before layout while preserving the established compilation structure
+                afterwards. ``v2`` is the original MQT Predictor strategy.
+                ``flexible`` provides the greatest freedom among all structurally
+                valid actions.
 
         Raises:
             ValueError: If the reward function is "estimated_success_probability" and no calibration data is available for the device or if the reward function is "estimated_hellinger_distance" and no trained model is available for the device.
         """
         logger.info("Init env: " + reward_function)
 
-        if mdp not in {"paper", "flexible", "thesis", "hybrid"}:
+        if mdp not in {"v2", "v3", "flexible"}:
             msg = f"Unsupported MDP policy: {mdp}."
             raise ValueError(msg)
 
@@ -636,77 +637,8 @@ class PredictorEnv(Env):
 
         actions = []
 
-        if self.mdp == "flexible":
-            if not synthesized and not laid_out:
-                actions.extend(self.actions_synthesis_indices)
-                actions.extend(self.actions_mapping_indices)
-                actions.extend(self.actions_layout_indices)
-                actions.extend(self.actions_opt_indices)
-            elif synthesized and not laid_out:
-                actions.extend(self.actions_mapping_indices)
-                actions.extend(self.actions_layout_indices)
-                actions.extend(self.actions_opt_indices)
-            elif not synthesized and laid_out and not routed:
-                actions.extend(self.actions_synthesis_indices)
-                actions.extend(self.actions_routing_indices)
-                actions.extend(self.actions_opt_indices)
-            elif synthesized and laid_out and not routed:
-                actions.extend(self.actions_routing_indices)
-                actions.extend(self.actions_opt_indices)
-            elif not synthesized and laid_out and routed:
-                actions.extend(self.actions_synthesis_indices)
-                actions.extend(self.actions_opt_indices)
-            else:
-                actions.append(self.action_terminate_index)
-                actions.extend(self.actions_opt_indices)
-
-        elif self.mdp == "hybrid":
-            if not synthesized and not laid_out:
-                actions.extend(self.actions_synthesis_indices)
-                actions.extend(self.actions_mapping_indices)
-                actions.extend(self.actions_layout_indices)
-                actions.extend(self.actions_opt_indices)
-            elif synthesized and not laid_out:
-                actions.extend(self.actions_mapping_indices)
-                actions.extend(self.actions_layout_indices)
-                actions.extend(self.actions_opt_indices)
-            elif not synthesized and laid_out and not routed:
-                actions.extend(self.actions_synthesis_indices)
-                actions.extend(self.actions_routing_indices)
-                actions.extend(self.actions_structure_preserving_indices)
-            elif synthesized and laid_out and not routed:
-                actions.extend(self.actions_routing_indices)
-                actions.extend(self.actions_structure_preserving_indices)
-            elif not synthesized and laid_out and routed:
-                actions.extend(self.actions_synthesis_indices)
-                actions.extend(self.actions_structure_preserving_indices)
-            else:
-                actions.append(self.action_terminate_index)
-                actions.extend(self.actions_structure_preserving_indices)
-                actions.extend(self.actions_final_optimization_indices)
-
-        elif self.mdp == "thesis":
-            if not synthesized and not laid_out:
-                actions.extend(self.actions_synthesis_indices)
-                actions.extend(self.actions_opt_indices)
-            elif synthesized and not laid_out:
-                actions.extend(self.actions_mapping_indices)
-                actions.extend(self.actions_layout_indices)
-                actions.extend(self.actions_opt_indices)
-            elif not synthesized and laid_out and not routed:
-                actions.extend(self.actions_synthesis_indices)
-                actions.extend(self.actions_structure_preserving_indices)
-            elif synthesized and laid_out and not routed:
-                actions.extend(self.actions_routing_indices)
-            elif not synthesized and laid_out and routed:
-                actions.extend(self.actions_synthesis_indices)
-                actions.extend(self.actions_structure_preserving_indices)
-            else:
-                actions.append(self.action_terminate_index)
-                actions.extend(self.actions_structure_preserving_indices)
-                actions.extend(self.actions_final_optimization_indices)
-
-        else:
+        if self.mdp == "v2":
+            # Initial state
             if not synthesized and not laid_out and not routed:
                 actions.extend(self.actions_synthesis_indices)
                 actions.extend(self.actions_opt_indices)
@@ -716,19 +648,72 @@ class PredictorEnv(Env):
                 actions.extend(self.actions_layout_indices)
                 actions.extend(self.actions_opt_indices)
 
+            # Not *depicted* in paper; necessary because optimization can destroy the native gate set
             elif not synthesized and laid_out and not routed:
                 actions.extend(self.actions_synthesis_indices)
                 actions.extend(self.actions_routing_indices)
                 actions.extend(self.actions_opt_indices)
 
+            # Not *depicted* in paper; necessary because of layout-only passes
             elif synthesized and laid_out and not routed:
                 actions.extend(self.actions_routing_indices)
 
+            # Not *depicted* in paper; necessary because routing can insert non-native SWAPs
             elif not synthesized and laid_out and routed:
                 actions.extend(self.actions_synthesis_indices)
                 actions.extend(self.actions_opt_indices)
 
+            # Final state
             elif synthesized and laid_out and routed:
+                actions.append(self.action_terminate_index)
+                actions.extend(self.actions_opt_indices)
+
+        elif self.mdp == "v3":
+            if not synthesized and not laid_out:
+                actions.extend(self.actions_synthesis_indices)
+                actions.extend(self.actions_mapping_indices)
+                actions.extend(self.actions_layout_indices)
+                actions.extend(self.actions_opt_indices)
+            elif synthesized and not laid_out:
+                actions.extend(self.actions_mapping_indices)
+                actions.extend(self.actions_layout_indices)
+                actions.extend(self.actions_opt_indices)
+            elif not synthesized and laid_out and not routed:
+                actions.extend(self.actions_synthesis_indices)
+                actions.extend(self.actions_routing_indices)
+                actions.extend(self.actions_structure_preserving_indices)
+            elif synthesized and laid_out and not routed:
+                actions.extend(self.actions_routing_indices)
+                actions.extend(self.actions_structure_preserving_indices)
+            elif not synthesized and laid_out and routed:
+                actions.extend(self.actions_synthesis_indices)
+                actions.extend(self.actions_structure_preserving_indices)
+            else:
+                actions.append(self.action_terminate_index)
+                actions.extend(self.actions_structure_preserving_indices)
+                actions.extend(self.actions_final_optimization_indices)
+
+        else:  # flexible
+            if not synthesized and not laid_out:
+                actions.extend(self.actions_synthesis_indices)
+                actions.extend(self.actions_mapping_indices)
+                actions.extend(self.actions_layout_indices)
+                actions.extend(self.actions_opt_indices)
+            elif synthesized and not laid_out:
+                actions.extend(self.actions_mapping_indices)
+                actions.extend(self.actions_layout_indices)
+                actions.extend(self.actions_opt_indices)
+            elif not synthesized and laid_out and not routed:
+                actions.extend(self.actions_synthesis_indices)
+                actions.extend(self.actions_routing_indices)
+                actions.extend(self.actions_opt_indices)
+            elif synthesized and laid_out and not routed:
+                actions.extend(self.actions_routing_indices)
+                actions.extend(self.actions_opt_indices)
+            elif not synthesized and laid_out and routed:
+                actions.extend(self.actions_synthesis_indices)
+                actions.extend(self.actions_opt_indices)
+            else:
                 actions.append(self.action_terminate_index)
                 actions.extend(self.actions_opt_indices)
 

--- a/src/mqt/predictor/rl/predictorenv.py
+++ b/src/mqt/predictor/rl/predictorenv.py
@@ -62,6 +62,7 @@ class PredictorEnv(Env):
         path_training_circuits: Path | None = None,
         max_steps: int | None = None,
         tracer_output_path: str | Path | None = None,
+        mdp: str = "paper",
     ) -> None:
         """Initializes the PredictorEnv object.
 
@@ -71,14 +72,23 @@ class PredictorEnv(Env):
             path_training_circuits: The path to the training circuits folder. Defaults to None, which uses the default path.
             max_steps: The maximum number of actions per episode. Defaults to None, which means no step limit is enforced.
             tracer_output_path: Path to export the compilation trace JSON. Defaults to None.
+            mdp: The MDP transition policy. ``paper`` follows the original linear
+                compilation flow, ``flexible`` permits all pre-routing actions,
+                ``thesis`` preserves the compilation structure after layout, and
+                ``hybrid`` is flexible until layout has been established.
 
         Raises:
             ValueError: If the reward function is "estimated_success_probability" and no calibration data is available for the device or if the reward function is "estimated_hellinger_distance" and no trained model is available for the device.
         """
         logger.info("Init env: " + reward_function)
 
+        if mdp not in {"paper", "flexible", "thesis", "hybrid"}:
+            msg = f"Unsupported MDP policy: {mdp}."
+            raise ValueError(msg)
+
         self.path_training_circuits = path_training_circuits or get_path_training_circuits()
         self.max_steps = max_steps
+        self.mdp = mdp
 
         self.action_set = {}
         self.actions_synthesis_indices = []
@@ -86,7 +96,10 @@ class PredictorEnv(Env):
         self.actions_routing_indices = []
         self.actions_mapping_indices = []
         self.actions_opt_indices = []
-        self.actions_final_optimization_indices = []  # TODO: currently not used; will be improved by addressing issue https://github.com/munich-quantum-toolkit/predictor/issues/666
+        self.actions_final_optimization_indices = []
+        self.actions_layout_preserving_indices = []
+        self.actions_routing_preserving_indices = []
+        self.actions_structure_preserving_indices = []
         self.used_actions: list[str] = []
         self.device = device
 
@@ -118,6 +131,12 @@ class PredictorEnv(Env):
         for elem in action_dict[PassType.OPT]:
             self.action_set[index] = elem
             self.actions_opt_indices.append(index)
+            if elem.preserves_layout:
+                self.actions_layout_preserving_indices.append(index)
+            if elem.preserves_layout and elem.preserves_routing:
+                self.actions_routing_preserving_indices.append(index)
+            if elem.preserves_layout and elem.preserves_routing and elem.preserves_synthesis:
+                self.actions_structure_preserving_indices.append(index)
             index += 1
         for elem in action_dict[PassType.MAPPING]:
             self.action_set[index] = elem
@@ -434,7 +453,7 @@ class PredictorEnv(Env):
                 device=self.device,
                 circuit_name=current_circuit_name,
                 figure_of_merit=self.reward_function,
-                mdp_policy="paper",  # Fallback since mdp refactoring is not yet implemented
+                mdp_policy=self.mdp,
             )
 
             # Record baseline
@@ -623,34 +642,62 @@ class PredictorEnv(Env):
 
         actions = []
 
-        # Initial state
-        if not synthesized and not laid_out and not routed:
-            actions.extend(self.actions_synthesis_indices)
+        if self.mdp == "flexible":
+            if not laid_out:
+                actions.extend(self.actions_synthesis_indices)
+                actions.extend(self.actions_mapping_indices)
+                actions.extend(self.actions_layout_indices)
+            elif not routed:
+                actions.extend(self.actions_synthesis_indices)
+                actions.extend(self.actions_routing_indices)
+            else:
+                actions.extend(self.actions_synthesis_indices)
             actions.extend(self.actions_opt_indices)
+            if synthesized and laid_out and routed:
+                actions.append(self.action_terminate_index)
 
-        if synthesized and not laid_out and not routed:
-            actions.extend(self.actions_mapping_indices)
-            actions.extend(self.actions_layout_indices)
-            actions.extend(self.actions_opt_indices)
+        elif self.mdp == "hybrid" or self.mdp == "thesis":
+            if not laid_out:
+                actions.extend(self.actions_synthesis_indices)
+                actions.extend(self.actions_mapping_indices)
+                actions.extend(self.actions_layout_indices)
+                actions.extend(self.actions_opt_indices)
+            elif not routed:
+                actions.extend(self.actions_synthesis_indices)
+                actions.extend(self.actions_routing_indices)
+                actions.extend(self.actions_layout_preserving_indices)
+            else:
+                actions.extend(self.actions_synthesis_indices)
+                actions.extend(self.actions_routing_preserving_indices)
+                if synthesized:
+                    actions.extend(self.actions_structure_preserving_indices)
+                    actions.extend(self.actions_final_optimization_indices)
+                    actions.append(self.action_terminate_index)
 
-        # Not *depicted* in paper; necessary because optimization can destroy the native gate set
-        if not synthesized and laid_out and not routed:
-            actions.extend(self.actions_synthesis_indices)
-            actions.extend(self.actions_routing_indices)
-            actions.extend(self.actions_opt_indices)
+        else:
+            if not synthesized and not laid_out and not routed:
+                actions.extend(self.actions_synthesis_indices)
+                actions.extend(self.actions_opt_indices)
 
-        # Not *depicted* in paper; necessary because of layout-only passes
-        if synthesized and laid_out and not routed:
-            actions.extend(self.actions_routing_indices)
+            elif synthesized and not laid_out and not routed:
+                actions.extend(self.actions_mapping_indices)
+                actions.extend(self.actions_layout_indices)
+                actions.extend(self.actions_opt_indices)
 
-        # Not *depicted* in paper; necessary because routing can insert non-native SWAPs
-        if not synthesized and laid_out and routed:
-            actions.extend(self.actions_synthesis_indices)
-            actions.extend(self.actions_opt_indices)
+            elif not synthesized and laid_out and not routed:
+                actions.extend(self.actions_synthesis_indices)
+                actions.extend(self.actions_routing_indices)
+                actions.extend(self.actions_opt_indices)
 
-        # Final state
-        if synthesized and laid_out and routed:
-            actions.extend([self.action_terminate_index])
-            actions.extend(self.actions_opt_indices)
+            elif synthesized and laid_out and not routed:
+                actions.extend(self.actions_routing_indices)
+
+            elif not synthesized and laid_out and routed:
+                actions.extend(self.actions_synthesis_indices)
+                actions.extend(self.actions_opt_indices)
+
+            elif synthesized and laid_out and routed:
+                actions.append(self.action_terminate_index)
+                actions.extend(self.actions_opt_indices)
 
         return actions

--- a/tests/compilation/test_predictor_rl.py
+++ b/tests/compilation/test_predictor_rl.py
@@ -82,7 +82,6 @@ def test_predictor_env_rejects_unsupported_mdp() -> None:
     [
         pytest.param("v2", ("synthesis", "optimization"), id="v2"),
         pytest.param("v3", ("synthesis", "mapping", "layout", "optimization"), id="v3"),
-        pytest.param("flexible", ("synthesis", "mapping", "layout", "optimization"), id="flexible"),
     ],
 )
 def test_predictor_env_reset_uses_mdp_initial_actions(
@@ -210,18 +209,6 @@ def test_predictor_env_truncates_at_max_steps() -> None:
                 (True, True, True): ("terminate", "structure-preserving", "final-optimization"),
             },
             id="v3",
-        ),
-        pytest.param(
-            "flexible",
-            {
-                (False, False, False): ("synthesis", "mapping", "layout", "optimization"),
-                (True, False, False): ("mapping", "layout", "optimization"),
-                (False, True, False): ("synthesis", "routing", "optimization"),
-                (True, True, False): ("routing", "optimization"),
-                (False, True, True): ("synthesis", "optimization"),
-                (True, True, True): ("terminate", "optimization", "final-optimization"),
-            },
-            id="flexible",
         ),
     ],
 )

--- a/tests/compilation/test_predictor_rl.py
+++ b/tests/compilation/test_predictor_rl.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 
 import re
 from pathlib import Path
-from typing import Literal, cast
+from typing import TYPE_CHECKING, cast
 
 import pytest
 from mqt.bench import BenchmarkLevel, get_benchmark
@@ -35,6 +35,9 @@ from mqt.predictor.rl.actions import (
     register_action,
 )
 from mqt.predictor.rl.helper import create_feature_dict, get_path_trained_model
+
+if TYPE_CHECKING:
+    from mqt.predictor.rl.predictorenv import MDPPolicy
 
 
 def test_predictor_env_reset_from_string() -> None:
@@ -68,7 +71,7 @@ def test_predictor_env_hellinger_error() -> None:
 
 def test_predictor_env_rejects_unsupported_mdp() -> None:
     """Test that unsupported MDP policies are rejected at runtime."""
-    invalid_mdp = cast("Literal['v2', 'v3', 'flexible']", "unsupported")
+    invalid_mdp = cast("MDPPolicy", "unsupported")
 
     with pytest.raises(ValueError, match=re.escape("Unsupported MDP policy: unsupported.")):
         predictorenv_module.PredictorEnv(device=get_device("ibm_falcon_27"), mdp=invalid_mdp)
@@ -84,7 +87,7 @@ def test_predictor_env_rejects_unsupported_mdp() -> None:
 )
 def test_predictor_env_reset_uses_mdp_initial_actions(
     monkeypatch: pytest.MonkeyPatch,
-    mdp: Literal["v2", "v3", "flexible"],
+    mdp: MDPPolicy,
     expected_action_groups: tuple[str, ...],
 ) -> None:
     """Test that reset initializes the action set for the selected MDP."""
@@ -220,7 +223,7 @@ def test_predictor_env_truncates_at_max_steps() -> None:
                 (False, True, False): ("synthesis", "routing", "optimization"),
                 (True, True, False): ("routing", "optimization"),
                 (False, True, True): ("synthesis", "optimization"),
-                (True, True, True): ("terminate", "optimization"),
+                (True, True, True): ("terminate", "optimization", "final-optimization"),
             },
             id="flexible",
         ),
@@ -228,7 +231,7 @@ def test_predictor_env_truncates_at_max_steps() -> None:
 )
 def test_predictor_env_actions_for_mdp_state(
     monkeypatch: pytest.MonkeyPatch,
-    mdp: Literal["v2", "v3", "flexible"],
+    mdp: MDPPolicy,
     expected_action_groups_by_state: dict[tuple[bool, bool, bool], tuple[str, ...]],
     synthesized: bool,
     laid_out: bool,

--- a/tests/compilation/test_predictor_rl.py
+++ b/tests/compilation/test_predictor_rl.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 import re
 from pathlib import Path
+from typing import Literal
 
 import pytest
 from mqt.bench import BenchmarkLevel, get_benchmark
@@ -136,29 +137,103 @@ def test_predictor_env_truncates_at_max_steps() -> None:
     assert info["truncation_reason"] == "max_steps_exceeded"
 
 
-def test_predictor_env_actions_after_layout_with_non_native_unrouted_circuit() -> None:
-    """Test valid actions for a laid-out circuit that still needs synthesis and routing."""
+@pytest.mark.parametrize(
+    ("synthesized", "laid_out", "routed"),
+    [
+        pytest.param(False, False, False, id="initial"),
+        pytest.param(True, False, False, id="synthesized"),
+        pytest.param(False, True, False, id="laid-out"),
+        pytest.param(True, True, False, id="synthesized-laid-out"),
+        pytest.param(False, True, True, id="laid-out-routed"),
+        pytest.param(True, True, True, id="final"),
+    ],
+)
+@pytest.mark.parametrize(
+    ("mdp", "expected_action_groups_by_state"),
+    [
+        pytest.param(
+            "v2",
+            {
+                (False, False, False): ("synthesis", "optimization"),
+                (True, False, False): ("mapping", "layout", "optimization"),
+                (False, True, False): ("synthesis", "routing", "optimization"),
+                (True, True, False): ("routing",),
+                (False, True, True): ("synthesis", "optimization"),
+                (True, True, True): ("terminate", "optimization"),
+            },
+            id="v2",
+        ),
+        pytest.param(
+            "v3",
+            {
+                (False, False, False): ("synthesis", "mapping", "layout", "optimization"),
+                (True, False, False): ("mapping", "layout", "optimization"),
+                (False, True, False): ("synthesis", "routing", "structure-preserving"),
+                (True, True, False): ("routing", "structure-preserving"),
+                (False, True, True): ("synthesis", "structure-preserving"),
+                (True, True, True): ("terminate", "structure-preserving", "final-optimization"),
+            },
+            id="v3",
+        ),
+        pytest.param(
+            "flexible",
+            {
+                (False, False, False): ("synthesis", "mapping", "layout", "optimization"),
+                (True, False, False): ("mapping", "layout", "optimization"),
+                (False, True, False): ("synthesis", "routing", "optimization"),
+                (True, True, False): ("routing", "optimization"),
+                (False, True, True): ("synthesis", "optimization"),
+                (True, True, True): ("terminate", "optimization"),
+            },
+            id="flexible",
+        ),
+    ],
+)
+def test_predictor_env_actions_for_mdp_state(
+    monkeypatch: pytest.MonkeyPatch,
+    mdp: Literal["v2", "v3", "flexible"],
+    expected_action_groups_by_state: dict[tuple[bool, bool, bool], tuple[str, ...]],
+    synthesized: bool,
+    laid_out: bool,
+    routed: bool,
+) -> None:
+    """Test the exact valid actions for every reachable state of each MDP."""
     device = get_device("ibm_falcon_27")
-    env = predictorenv_module.PredictorEnv(device=device)
+    env = predictorenv_module.PredictorEnv(device=device, mdp=mdp)
     qc = QuantumCircuit(3)
     qc.h(0)
     qc.cx(0, 2)
     env.reset(qc)
 
-    env.layout = TranspileLayout(
-        initial_layout=Layout({qubit: index for index, qubit in enumerate(qc.qubits)}),
-        input_qubit_mapping={qubit: index for index, qubit in enumerate(qc.qubits)},
-        final_layout=None,
-        _output_qubit_list=qc.qubits,
-        _input_qubit_count=qc.num_qubits,
-    )
+    if laid_out:
+        env.layout = TranspileLayout(
+            initial_layout=Layout({qubit: index for index, qubit in enumerate(qc.qubits)}),
+            input_qubit_mapping={qubit: index for index, qubit in enumerate(qc.qubits)},
+            final_layout=None,
+            _output_qubit_list=qc.qubits,
+            _input_qubit_count=qc.num_qubits,
+        )
+
+    monkeypatch.setattr(env, "is_circuit_synthesized", lambda _circuit: synthesized)
+    monkeypatch.setattr(env, "is_circuit_laid_out", lambda _circuit, _layout: laid_out)
+    monkeypatch.setattr(env, "is_circuit_routed", lambda _circuit, _coupling_map: routed)
+
+    action_groups = {
+        "synthesis": env.actions_synthesis_indices,
+        "mapping": env.actions_mapping_indices,
+        "layout": env.actions_layout_indices,
+        "routing": env.actions_routing_indices,
+        "optimization": env.actions_opt_indices,
+        "structure-preserving": env.actions_structure_preserving_indices,
+        "final-optimization": env.actions_final_optimization_indices,
+        "terminate": [env.action_terminate_index],
+    }
+    expected_action_groups = expected_action_groups_by_state[synthesized, laid_out, routed]
+    expected_actions = {action for group in expected_action_groups for action in action_groups[group]}
 
     valid_actions = env.determine_valid_actions_for_state()
 
-    assert set(env.actions_synthesis_indices).issubset(valid_actions)
-    assert set(env.actions_routing_indices).issubset(valid_actions)
-    assert set(env.actions_opt_indices).issubset(valid_actions)
-    assert env.action_terminate_index not in valid_actions
+    assert set(valid_actions) == expected_actions
 
 
 def test_predictor_env_qiskit_routing_updates_final_layout(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/compilation/test_predictor_rl.py
+++ b/tests/compilation/test_predictor_rl.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 
 import re
 from pathlib import Path
-from typing import Literal
+from typing import Literal, cast
 
 import pytest
 from mqt.bench import BenchmarkLevel, get_benchmark
@@ -64,6 +64,43 @@ def test_predictor_env_hellinger_error() -> None:
         ValueError, match=re.escape("Missing trained model for Hellinger distance estimates on ibm_falcon_27.")
     ):
         Predictor(figure_of_merit="estimated_hellinger_distance", device=device)
+
+
+def test_predictor_env_rejects_unsupported_mdp() -> None:
+    """Test that unsupported MDP policies are rejected at runtime."""
+    invalid_mdp = cast("Literal['v2', 'v3', 'flexible']", "unsupported")
+
+    with pytest.raises(ValueError, match=re.escape("Unsupported MDP policy: unsupported.")):
+        predictorenv_module.PredictorEnv(device=get_device("ibm_falcon_27"), mdp=invalid_mdp)
+
+
+@pytest.mark.parametrize(
+    ("mdp", "expected_action_groups"),
+    [
+        pytest.param("v2", ("synthesis", "optimization"), id="v2"),
+        pytest.param("v3", ("synthesis", "mapping", "layout", "optimization"), id="v3"),
+        pytest.param("flexible", ("synthesis", "mapping", "layout", "optimization"), id="flexible"),
+    ],
+)
+def test_predictor_env_reset_uses_mdp_initial_actions(
+    monkeypatch: pytest.MonkeyPatch,
+    mdp: Literal["v2", "v3", "flexible"],
+    expected_action_groups: tuple[str, ...],
+) -> None:
+    """Test that reset initializes the action set for the selected MDP."""
+    env = predictorenv_module.PredictorEnv(device=get_device("ibm_falcon_27"), mdp=mdp)
+    monkeypatch.setattr(env, "is_circuit_synthesized", lambda _circuit: False)
+
+    env.reset(QuantumCircuit(1))
+
+    action_groups = {
+        "synthesis": env.actions_synthesis_indices,
+        "mapping": env.actions_mapping_indices,
+        "layout": env.actions_layout_indices,
+        "optimization": env.actions_opt_indices,
+    }
+    expected_actions = {action for group in expected_action_groups for action in action_groups[group]}
+    assert set(env.valid_actions) == expected_actions
 
 
 def test_qcompile_with_newly_trained_models() -> None:

--- a/tests/compilation/test_predictor_rl.py
+++ b/tests/compilation/test_predictor_rl.py
@@ -86,13 +86,11 @@ def test_predictor_env_rejects_unsupported_mdp() -> None:
     ],
 )
 def test_predictor_env_reset_uses_mdp_initial_actions(
-    monkeypatch: pytest.MonkeyPatch,
     mdp: MDPPolicy,
     expected_action_groups: tuple[str, ...],
 ) -> None:
     """Test that reset initializes the action set for the selected MDP."""
     env = predictorenv_module.PredictorEnv(device=get_device("ibm_falcon_27"), mdp=mdp)
-    monkeypatch.setattr(env, "is_circuit_synthesized", lambda _circuit: False)
 
     env.reset(QuantumCircuit(1))
 
@@ -117,14 +115,12 @@ def test_qcompile_with_newly_trained_models() -> None:
     qc = get_benchmark("ghz", BenchmarkLevel.ALG, 3)
     predictor = Predictor(figure_of_merit=figure_of_merit, device=device)
 
-    model_name = "model_" + figure_of_merit + "_" + device.description
+    model_name = predictor.model_name
     model_path = Path(get_path_trained_model() / (model_name + ".zip"))
     if not model_path.exists():
         with pytest.raises(
             FileNotFoundError,
-            match=re.escape(
-                "The RL model 'model_expected_fidelity_ibm_falcon_127' is not trained yet. Please train the model before using it."
-            ),
+            match=re.escape(f"The RL model '{model_name}' is not trained yet. Please train the model before using it."),
         ):
             rl_compile(qc, device=device, figure_of_merit=figure_of_merit)
 


### PR DESCRIPTION
🤖 *AI text below* 🤖

## Description

Adds selectable `v2` and `v3` MDP transition policies for the reinforcement-learning compiler. `v2` preserves the original MQT Predictor behavior, while `v3` is the new default and permits broader compilation choices before layout while preserving structure afterwards.

`PredictorEnv`, `Predictor`, and `rl_compile` accept only `v2` and `v3`. Compilation traces record the selected policy, and trained-model artifact names include it.

Existing models trained with the original policy remain compatible with `v2`: copy or rename `model_<figure_of_merit>_<device>.zip` to `model_<figure_of_merit>_<device>_v2.zip`, then select `mdp="v2"`. Models for `v3` must be retrained.

Rebased onto current main after the #801 revert. The hard-horizon change remains separate in draft #830.

Validation: 24 focused MDP, environment, horizon, and tracing tests passed; full `uvx nox -s lint` passed. CI, including model training, docs, and patch coverage passes on the updated head.

Fixes #666

Part of #664

## Checklist

- [x] The pull request only contains commits that are focused and relevant to this change.
- [x] I have added appropriate tests that cover the new/changed functionality.
- [x] I have updated the documentation to reflect these changes.
- [x] I have added entries to the changelog for any noteworthy additions, changes, fixes, or removals.
- [x] I have added migration instructions to the upgrade guide (if needed).
- [x] The changes follow the project's style guidelines and introduce no new warnings.
- [x] The changes are fully tested and pass the CI checks.
- [x] I have reviewed my own code changes.

**If PR contains AI-assisted content:**

- [x] Any agent that created, edited, or submitted GitHub content was explicitly authorized for that scope, as required by our [AI Usage Guidelines](https://github.com/munich-quantum-toolkit/predictor/blob/main/docs/ai_usage.md).
- [x] Every agent-authored or agent-edited public text body begins with the visible disclosure `🤖 *AI text below* 🤖` (titles are exempt).
- [x] I have disclosed AI assistance in the PR description.
- [x] I confirm that I have personally reviewed and understood all AI-generated content, and accept full responsibility for it.
