### PR TITLE
✨ Add intermediate rewards to RL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ releases may include breaking changes.
 ### Added
 
 - ✨ Add Qiskit's `TrivialLayout`, `ElidePermutations`, `SabreSwap`,
-  `BasicSwap`, `LookaheadSwap`, `GateDirection`, `RemoveIdentityEquivalent`, and
+  `BasicSwap`, `LookaheadSwap`, `RemoveIdentityEquivalent`, and
   `Optimize1qGatesSimpleCommutation` passes to the RL actions ([#759])
   ([**@flowerthrower**])
 - ✨ Expand and compact the RL observation with normalized OpenQASM operation

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,9 @@ releases may include breaking changes.
 
 ### Added
 
-- ✨ Add Qiskit's stochastic `SabreSwap` pass to the RL routing actions ([#759])
+- ✨ Add Qiskit's `TrivialLayout`, `ElidePermutations`, `SabreSwap`,
+  `BasicSwap`, `LookaheadSwap`, `GateDirection`, `RemoveIdentityEquivalent`, and
+  `Optimize1qGatesSimpleCommutation` passes to the RL actions ([#759])
   ([**@flowerthrower**])
 - ✨ Expand and compact the RL observation with normalized OpenQASM operation
   frequencies and one-element `float32` qubit-count and depth arrays, and
@@ -27,6 +29,8 @@ releases may include breaking changes.
 
 ### Changed
 
+- 🐛 Make the `OptimizeCliffords` RL action collect standard Clifford gates
+  before optimizing them ([#759]) ([**@flowerthrower**])
 - 🔥 Drop support for Python 3.10 ([#773]) ([**@denialhaag**])
 - ♻️ Split RL actions package into `base` and `registry` modules ([#769])
   ([**@denialhaag**])

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ releases may include breaking changes.
   frequencies and one-element `float32` qubit-count and depth arrays, and
   include measurements in the shared ML feature schema ([#758])
   ([**@flowerthrower**])
+- ✨ Evaluate configurable repeated candidates for stochastic Qiskit RL actions
+  and retain the highest-scoring result ([#757]) ([**@flowerthrower**])
 - 👷 Enable testing on Python 3.14 ([#488]) ([**@denialhaag**])
 - ✨ Add selectable `v2` and `v3` RL MDP strategies, make `v3` the default, and
   use the selected strategy in compilation traces and model artifact names
@@ -94,6 +96,7 @@ for previous changelogs._
 [#773]: https://github.com/munich-quantum-toolkit/predictor/pull/771
 [#769]: https://github.com/munich-quantum-toolkit/predictor/pull/769
 [#758]: https://github.com/munich-quantum-toolkit/predictor/pull/758
+[#757]: https://github.com/munich-quantum-toolkit/predictor/pull/757
 [#755]: https://github.com/munich-quantum-toolkit/predictor/pull/755
 [#731]: https://github.com/munich-quantum-toolkit/predictor/pull/731
 [#714]: https://github.com/munich-quantum-toolkit/predictor/pull/714

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,8 @@ releases may include breaking changes.
 
 ### Changed
 
+- ✨ Enable configurable intermediate rewards for RL training by default
+  ([#760]) ([**@flowerthrower**])
 - 🐛 Make the `OptimizeCliffords` RL action collect standard Clifford gates
   before optimizing them ([#759]) ([**@flowerthrower**])
 - 🔥 Drop support for Python 3.10 ([#773]) ([**@denialhaag**])
@@ -101,6 +103,7 @@ for previous changelogs._
 
 [#773]: https://github.com/munich-quantum-toolkit/predictor/pull/771
 [#769]: https://github.com/munich-quantum-toolkit/predictor/pull/769
+[#760]: https://github.com/munich-quantum-toolkit/predictor/pull/760
 [#759]: https://github.com/munich-quantum-toolkit/predictor/pull/759
 [#758]: https://github.com/munich-quantum-toolkit/predictor/pull/758
 [#757]: https://github.com/munich-quantum-toolkit/predictor/pull/757

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ releases may include breaking changes.
 
 ### Added
 
+- ✨ Add Qiskit's stochastic `SabreSwap` pass to the RL routing actions ([#759])
+  ([**@flowerthrower**])
 - ✨ Expand and compact the RL observation with normalized OpenQASM operation
   frequencies and one-element `float32` qubit-count and depth arrays, and
   include measurements in the shared ML feature schema ([#758])
@@ -95,6 +97,7 @@ for previous changelogs._
 
 [#773]: https://github.com/munich-quantum-toolkit/predictor/pull/771
 [#769]: https://github.com/munich-quantum-toolkit/predictor/pull/769
+[#759]: https://github.com/munich-quantum-toolkit/predictor/pull/759
 [#758]: https://github.com/munich-quantum-toolkit/predictor/pull/758
 [#757]: https://github.com/munich-quantum-toolkit/predictor/pull/757
 [#755]: https://github.com/munich-quantum-toolkit/predictor/pull/755

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -22,6 +22,14 @@ Starting with this release, MQT Predictor no longer supports Python 3.10. As a
 result, MQT Predictor is no longer tested under Python 3.10 and requires Python
 3.11 or later.
 
+### Repeated stochastic Qiskit actions
+
+The stochastic `QiskitSabreMapping` action now evaluates 20 candidates by
+default and retains the candidate with the best configured figure of merit. This
+can increase compilation time and change the selected circuit. Set
+`stochastic_action_trials=1` when constructing `PredictorEnv` to retain the
+previous single-attempt behavior.
+
 ### Atomic BQSKit compilation actions
 
 The composite actions `BQSKitO2`, `BQSKitSynthesis`, and `BQSKitMapping` are no

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -11,8 +11,7 @@ of changes including minor and patch releases, please refer to the
 The RL action space now includes the following Qiskit passes:
 
 - the `TrivialLayout` and `ElidePermutations` layout actions;
-- the `SabreSwap`, `BasicSwap`, `LookaheadSwap`, and `GateDirection` routing
-  actions; and
+- the `SabreSwap`, `BasicSwap`, and `LookaheadSwap` routing actions; and
 - the `RemoveIdentityEquivalent` and `Optimize1qGatesSimpleCommutation`
   optimization actions.
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -6,9 +6,21 @@ of changes including minor and patch releases, please refer to the
 
 ## [Unreleased]
 
-### Qiskit SABRE routing action
+### Expanded Qiskit action set
 
-The RL action space now includes Qiskit's stochastic `SabreSwap` routing pass.
+The RL action space now includes the following Qiskit passes:
+
+- the `TrivialLayout` and `ElidePermutations` layout actions;
+- the `SabreSwap`, `BasicSwap`, `LookaheadSwap`, and `GateDirection` routing
+  actions; and
+- the `RemoveIdentityEquivalent` and `Optimize1qGatesSimpleCommutation`
+  optimization actions.
+
+`ElidePermutations` establishes a trivial layout in the same action so its
+output permutation remains part of the canonical layout. `OptimizeCliffords` now
+collects standard Clifford gates before optimizing and decomposes the result for
+subsequent passes.
+
 Existing RL models must be retrained because the action-space size and the
 indices of later actions have changed. Code that persists or selects actions by
 numeric index must be updated.

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -6,6 +6,15 @@ of changes including minor and patch releases, please refer to the
 
 ## [Unreleased]
 
+### Intermediate RL rewards
+
+`PredictorEnv` now enables intermediate rewards by default. For
+`expected_fidelity` and `estimated_success_probability`, comparable non-terminal
+steps are rewarded from changes in the exact or approximate figure of merit.
+Optimization actions with no measurable change receive `-0.001`. Set
+`intermediate_reward=False` to retain the previous terminal-only reward
+behavior; use `reward_scale` and `no_effect_penalty` to tune reward shaping.
+
 ### Expanded Qiskit action set
 
 The RL action space now includes the following Qiskit passes:

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -6,6 +6,13 @@ of changes including minor and patch releases, please refer to the
 
 ## [Unreleased]
 
+### Qiskit SABRE routing action
+
+The RL action space now includes Qiskit's stochastic `SabreSwap` routing pass.
+Existing RL models must be retrained because the action-space size and the
+indices of later actions have changed. Code that persists or selects actions by
+numeric index must be updated.
+
 ### RL observation features
 
 The RL observation now includes normalized frequencies for supported OpenQASM

--- a/src/mqt/predictor/rl/actions/base.py
+++ b/src/mqt/predictor/rl/actions/base.py
@@ -52,6 +52,7 @@ class Action:
         preserves_layout: Whether action preserves existing layout.
         preserves_routing: Whether action preserves existing routing.
         preserves_synthesis: Whether action preserves synthesis state.
+        stochastic: Whether repeated execution can yield different results.
     """
 
     name: str
@@ -61,6 +62,7 @@ class Action:
     preserves_layout: bool = False
     preserves_routing: bool = False
     preserves_synthesis: bool = False
+    stochastic: bool = False
 
 
 @dataclass

--- a/src/mqt/predictor/rl/actions/bqskit_actions.py
+++ b/src/mqt/predictor/rl/actions/bqskit_actions.py
@@ -39,6 +39,8 @@ from bqskit.passes import (
     IfThenElsePass,
     LEAPSynthesisPass,
     ManyQuditGatesPredicate,
+    MGDPass,
+    QSDPass,
     QSearchSynthesisPass,
     RestoreMeasurements,
     SetModelPass,
@@ -308,6 +310,18 @@ def bqskit_synthesis_actions() -> list[Action]:
                 device,
                 IfThenElsePass(DiagonalPredicate(1e-9), WalshDiagonalSynthesisPass()),
             ),
+        ),
+        DeferredDeviceAction(
+            "QSDPass",
+            CompilationOrigin.BQSKIT,
+            PassType.SYNTHESIS,
+            transpile_pass=lambda device: _bqskit_partitioned_synthesis_factory(device, QSDPass()),
+        ),
+        DeferredDeviceAction(
+            "MGDPass",
+            CompilationOrigin.BQSKIT,
+            PassType.SYNTHESIS,
+            transpile_pass=lambda device: _bqskit_partitioned_synthesis_factory(device, MGDPass()),
         ),
         DeferredDeviceAction(
             "FullQSDPass",

--- a/src/mqt/predictor/rl/actions/qiskit_actions.py
+++ b/src/mqt/predictor/rl/actions/qiskit_actions.py
@@ -352,18 +352,25 @@ def run_qiskit_action(
     Stochastic actions are evaluated repeatedly when a score function is
     supplied. The highest-scoring result is retained together with its layout.
     """
-    attempts = stochastic_action_trials if action.stochastic and score is not None else 1
+    stochastic_run = action.stochastic and score is not None
+    attempts = stochastic_action_trials if stochastic_run else 1
     best_result: tuple[QuantumCircuit, TranspileLayout | None] | None = None
     best_score: float | None = None
 
-    for _ in range(max(1, attempts)):
-        altered_qc, candidate_layout = _run_qiskit_action_once(
-            action,
-            circuit,
-            device,
-            deepcopy(layout) if attempts > 1 else layout,
-            input_qubit_count,
-        )
+    for attempt in range(max(1, attempts)):
+        try:
+            altered_qc, candidate_layout = _run_qiskit_action_once(
+                action,
+                circuit,
+                device,
+                deepcopy(layout) if stochastic_run else layout,
+                input_qubit_count,
+            )
+        except Exception:
+            if not stochastic_run:
+                raise
+            logger.exception("Stochastic action %s failed on attempt %d.", action.name, attempt + 1)
+            continue
         if score is None:
             return altered_qc, candidate_layout
 
@@ -376,8 +383,10 @@ def run_qiskit_action(
             best_result = altered_qc, candidate_layout
             best_score = candidate_score
 
-    assert best_result is not None
-    return best_result
+    if best_result is not None:
+        return best_result
+    logger.error("All attempts for stochastic action %s failed.", action.name)
+    return circuit, layout
 
 
 def _run_qiskit_action_once(

--- a/src/mqt/predictor/rl/actions/qiskit_actions.py
+++ b/src/mqt/predictor/rl/actions/qiskit_actions.py
@@ -10,8 +10,8 @@
 
 from __future__ import annotations
 
-from copy import deepcopy
 import logging
+from copy import deepcopy
 from typing import TYPE_CHECKING, cast
 
 from qiskit.circuit import StandardEquivalenceLibrary

--- a/src/mqt/predictor/rl/actions/qiskit_actions.py
+++ b/src/mqt/predictor/rl/actions/qiskit_actions.py
@@ -361,7 +361,7 @@ def run_qiskit_action(
             action,
             circuit,
             device,
-            deepcopy(layout),
+            deepcopy(layout) if attempts > 1 else layout,
             input_qubit_count,
         )
         if score is None:
@@ -388,7 +388,6 @@ def _run_qiskit_action_once(
     input_qubit_count: int | None,
 ) -> tuple[QuantumCircuit, TranspileLayout | None]:
     """Run one Qiskit action attempt and update its layout metadata."""
-    # Build the concrete Qiskit pass list for a single attempt.
     if action.name == "QiskitO3" and isinstance(action, DeferredDeviceAction):
         factory = cast("Callable[[list[str], CouplingMap | None], list[Task]]", action.transpile_pass)
         passes = factory(device.operation_names, CouplingMap(device.build_coupling_map()) if layout else None)

--- a/src/mqt/predictor/rl/actions/qiskit_actions.py
+++ b/src/mqt/predictor/rl/actions/qiskit_actions.py
@@ -55,6 +55,7 @@ from qiskit.transpiler.passes import (
     OptimizeCliffords,
     RemoveDiagonalGatesBeforeMeasure,
     SabreLayout,
+    SabreSwap,
     Size,
     UnitarySynthesis,
     VF2Layout,
@@ -250,6 +251,20 @@ def qiskit_layout_actions() -> list[Action]:
                 ],
             ),
         ),
+    ]
+
+
+def qiskit_routing_actions() -> list[Action]:
+    """Return the Qiskit routing actions."""
+    return [
+        DeferredDeviceAction(
+            "SabreSwap",
+            CompilationOrigin.QISKIT,
+            PassType.ROUTING,
+            transpile_pass=lambda device: cast(
+                "list[Task]", [SabreSwap(coupling_map=CouplingMap(device.build_coupling_map()), heuristic="decay")]
+            ),
+        )
     ]
 
 

--- a/src/mqt/predictor/rl/actions/qiskit_actions.py
+++ b/src/mqt/predictor/rl/actions/qiskit_actions.py
@@ -10,6 +10,7 @@
 
 from __future__ import annotations
 
+from copy import deepcopy
 import logging
 from typing import TYPE_CHECKING, cast
 
@@ -258,6 +259,7 @@ def qiskit_mapping_action() -> Action:
         "QiskitSabreMapping",
         CompilationOrigin.QISKIT,
         PassType.MAPPING,
+        stochastic=True,
         transpile_pass=lambda device: cast(
             "list[Task]", [SabreLayout(coupling_map=CouplingMap(device.build_coupling_map()), skip_routing=False)]
         ),
@@ -342,9 +344,51 @@ def run_qiskit_action(
     device: Target,
     layout: TranspileLayout | None,
     input_qubit_count: int | None = None,
+    stochastic_action_trials: int = 1,
+    score: Callable[[QuantumCircuit], float] | None = None,
 ) -> tuple[QuantumCircuit, TranspileLayout | None]:
-    """Apply a Qiskit action and return the updated circuit and layout metadata."""
-    # Build the concrete Qiskit pass list for given action.
+    """Apply a Qiskit action and return the updated circuit and layout metadata.
+
+    Stochastic actions are evaluated repeatedly when a score function is
+    supplied. The highest-scoring result is retained together with its layout.
+    """
+    attempts = stochastic_action_trials if action.stochastic and score is not None else 1
+    best_result: tuple[QuantumCircuit, TranspileLayout | None] | None = None
+    best_score: float | None = None
+
+    for _ in range(max(1, attempts)):
+        altered_qc, candidate_layout = _run_qiskit_action_once(
+            action,
+            circuit,
+            device,
+            deepcopy(layout),
+            input_qubit_count,
+        )
+        if score is None:
+            return altered_qc, candidate_layout
+
+        try:
+            candidate_score = score(altered_qc)
+        except Exception:  # ruff:ignore[blind-except]
+            logger.warning("Could not evaluate stochastic action %s; using swap count instead.", action.name)
+            candidate_score = -float(altered_qc.count_ops().get("swap", 0))
+        if best_score is None or candidate_score > best_score:
+            best_result = altered_qc, candidate_layout
+            best_score = candidate_score
+
+    assert best_result is not None
+    return best_result
+
+
+def _run_qiskit_action_once(
+    action: Action,
+    circuit: QuantumCircuit,
+    device: Target,
+    layout: TranspileLayout | None,
+    input_qubit_count: int | None,
+) -> tuple[QuantumCircuit, TranspileLayout | None]:
+    """Run one Qiskit action attempt and update its layout metadata."""
+    # Build the concrete Qiskit pass list for a single attempt.
     if action.name == "QiskitO3" and isinstance(action, DeferredDeviceAction):
         factory = cast("Callable[[list[str], CouplingMap | None], list[Task]]", action.transpile_pass)
         passes = factory(device.operation_names, CouplingMap(device.build_coupling_map()) if layout else None)

--- a/src/mqt/predictor/rl/actions/qiskit_actions.py
+++ b/src/mqt/predictor/rl/actions/qiskit_actions.py
@@ -51,7 +51,6 @@ from qiskit.transpiler.passes import (
     EnlargeWithAncilla,
     FixedPoint,
     FullAncillaAllocation,
-    GateDirection,
     GatesInBasis,
     InverseCancellation,
     LookaheadSwap,
@@ -351,15 +350,6 @@ def qiskit_routing_actions() -> list[Action]:
                 ],
             ),
         ),
-        DeferredDeviceAction(
-            "GateDirection",
-            CompilationOrigin.QISKIT,
-            PassType.ROUTING,
-            transpile_pass=lambda device: cast(
-                "list[Task]",
-                [GateDirection(coupling_map=CouplingMap(device.build_coupling_map()), target=device)],
-            ),
-        ),
     ]
 
 
@@ -538,15 +528,7 @@ def _run_qiskit_action_once(
     return altered_qc, layout
 
 
-def is_qiskit_action_available(action: Action, circuit: QuantumCircuit, device: Target) -> bool:
+def is_qiskit_action_available(action: Action, device: Target) -> bool:
     """Return whether a Qiskit action is available for the current device."""
-    if action.name == "GateDirection":
-        undirected_edges = {frozenset(edge) for edge in device.build_coupling_map().get_edges()}
-        return all(
-            frozenset(circuit.find_bit(qubit).index for qubit in instruction.qubits) in undirected_edges
-            for instruction in circuit.data
-            if len(instruction.qubits) == 2
-        )
-
     # Only allow VF2PostLayout if "ibm" is in the device name # TODO: Why?
     return action.name != "VF2PostLayout" or "ibm" in device.description

--- a/src/mqt/predictor/rl/actions/qiskit_actions.py
+++ b/src/mqt/predictor/rl/actions/qiskit_actions.py
@@ -38,25 +38,33 @@ from qiskit.passmanager.flow_controllers import DoWhileController
 from qiskit.transpiler import CouplingMap, PassManager, TranspileLayout
 from qiskit.transpiler.passes import (
     ApplyLayout,
+    BasicSwap,
     BasisTranslator,
     Collect2qBlocks,
+    CollectCliffords,
     CommutativeCancellation,
     CommutativeInverseCancellation,
     ConsolidateBlocks,
     DenseLayout,
     Depth,
+    ElidePermutations,
     EnlargeWithAncilla,
     FixedPoint,
     FullAncillaAllocation,
+    GateDirection,
     GatesInBasis,
     InverseCancellation,
+    LookaheadSwap,
     MinimumPoint,
     Optimize1qGatesDecomposition,
+    Optimize1qGatesSimpleCommutation,
     OptimizeCliffords,
     RemoveDiagonalGatesBeforeMeasure,
+    RemoveIdentityEquivalent,
     SabreLayout,
     SabreSwap,
     Size,
+    TrivialLayout,
     UnitarySynthesis,
     VF2Layout,
     VF2PostLayout,
@@ -151,7 +159,7 @@ def qiskit_optimization_actions() -> list[Action]:
             "OptimizeCliffords",
             CompilationOrigin.QISKIT,
             PassType.OPT,
-            [OptimizeCliffords()],
+            [CollectCliffords(), OptimizeCliffords()],
             preserves_layout=True,
             preserves_routing=False,
             preserves_synthesis=False,
@@ -164,6 +172,32 @@ def qiskit_optimization_actions() -> list[Action]:
             preserves_layout=True,
             preserves_routing=True,
             preserves_synthesis=False,
+        ),
+        DeviceIndependentAction(
+            "RemoveIdentityEquivalent",
+            CompilationOrigin.QISKIT,
+            PassType.OPT,
+            [RemoveIdentityEquivalent()],
+            preserves_layout=True,
+            preserves_routing=True,
+            preserves_synthesis=True,
+        ),
+        DeferredDeviceAction(
+            "Optimize1qGatesSimpleCommutation",
+            CompilationOrigin.QISKIT,
+            PassType.OPT,
+            transpile_pass=lambda device: cast(
+                "list[Task]",
+                [
+                    Optimize1qGatesSimpleCommutation(
+                        basis=device.operation_names,
+                        run_to_completion=True,
+                    )
+                ],
+            ),
+            preserves_layout=True,
+            preserves_routing=True,
+            preserves_synthesis=True,
         ),
     ]
 
@@ -251,6 +285,35 @@ def qiskit_layout_actions() -> list[Action]:
                 ],
             ),
         ),
+        DeferredDeviceAction(
+            "TrivialLayout",
+            CompilationOrigin.QISKIT,
+            PassType.LAYOUT,
+            transpile_pass=lambda device: cast(
+                "list[Task]",
+                [
+                    TrivialLayout(coupling_map=CouplingMap(device.build_coupling_map())),
+                    FullAncillaAllocation(coupling_map=CouplingMap(device.build_coupling_map())),
+                    EnlargeWithAncilla(),
+                    ApplyLayout(),
+                ],
+            ),
+        ),
+        DeferredDeviceAction(
+            "ElidePermutations",
+            CompilationOrigin.QISKIT,
+            PassType.LAYOUT,
+            transpile_pass=lambda device: cast(
+                "list[Task]",
+                [
+                    ElidePermutations(),
+                    TrivialLayout(coupling_map=CouplingMap(device.build_coupling_map())),
+                    FullAncillaAllocation(coupling_map=CouplingMap(device.build_coupling_map())),
+                    EnlargeWithAncilla(),
+                    ApplyLayout(),
+                ],
+            ),
+        ),
     ]
 
 
@@ -264,7 +327,39 @@ def qiskit_routing_actions() -> list[Action]:
             transpile_pass=lambda device: cast(
                 "list[Task]", [SabreSwap(coupling_map=CouplingMap(device.build_coupling_map()), heuristic="decay")]
             ),
-        )
+        ),
+        DeferredDeviceAction(
+            "BasicSwap",
+            CompilationOrigin.QISKIT,
+            PassType.ROUTING,
+            transpile_pass=lambda device: cast(
+                "list[Task]", [BasicSwap(coupling_map=CouplingMap(device.build_coupling_map()))]
+            ),
+        ),
+        DeferredDeviceAction(
+            "LookaheadSwap",
+            CompilationOrigin.QISKIT,
+            PassType.ROUTING,
+            transpile_pass=lambda device: cast(
+                "list[Task]",
+                [
+                    LookaheadSwap(
+                        coupling_map=CouplingMap(device.build_coupling_map()),
+                        search_depth=1,
+                        search_width=1,
+                    )
+                ],
+            ),
+        ),
+        DeferredDeviceAction(
+            "GateDirection",
+            CompilationOrigin.QISKIT,
+            PassType.ROUTING,
+            transpile_pass=lambda device: cast(
+                "list[Task]",
+                [GateDirection(coupling_map=CouplingMap(device.build_coupling_map()), target=device)],
+            ),
+        ),
     ]
 
 
@@ -437,11 +532,21 @@ def _run_qiskit_action_once(
     if altered_qc.count_ops().get("unitary"):
         # Custom "unitary" gates can not be processed further by other passes
         altered_qc = altered_qc.decompose(gates_to_decompose="unitary")
+    if altered_qc.count_ops().get("clifford"):
+        altered_qc = altered_qc.decompose(gates_to_decompose="clifford")
 
     return altered_qc, layout
 
 
-def is_qiskit_action_available(action: Action, device: Target) -> bool:
+def is_qiskit_action_available(action: Action, circuit: QuantumCircuit, device: Target) -> bool:
     """Return whether a Qiskit action is available for the current device."""
+    if action.name == "GateDirection":
+        undirected_edges = {frozenset(edge) for edge in device.build_coupling_map().get_edges()}
+        return all(
+            frozenset(circuit.find_bit(qubit).index for qubit in instruction.qubits) in undirected_edges
+            for instruction in circuit.data
+            if len(instruction.qubits) == 2
+        )
+
     # Only allow VF2PostLayout if "ibm" is in the device name # TODO: Why?
     return action.name != "VF2PostLayout" or "ibm" in device.description

--- a/src/mqt/predictor/rl/actions/qiskit_actions.py
+++ b/src/mqt/predictor/rl/actions/qiskit_actions.py
@@ -323,6 +323,7 @@ def qiskit_routing_actions() -> list[Action]:
             "SabreSwap",
             CompilationOrigin.QISKIT,
             PassType.ROUTING,
+            stochastic=True,
             transpile_pass=lambda device: cast(
                 "list[Task]", [SabreSwap(coupling_map=CouplingMap(device.build_coupling_map()), heuristic="decay")]
             ),

--- a/src/mqt/predictor/rl/actions/registry.py
+++ b/src/mqt/predictor/rl/actions/registry.py
@@ -57,6 +57,7 @@ for _action in (
     qiskit_actions.qiskit_o3_action(),
     *qiskit_actions.qiskit_optimization_actions(),
     qiskit_actions.qiskit_final_optimization_action(),
+    *tket_actions.tket_layout_actions(),
     tket_actions.tket_routing_action(),
     *tket_actions.tket_optimization_actions(),
     *bqskit_actions.bqskit_layout_actions(),

--- a/src/mqt/predictor/rl/actions/registry.py
+++ b/src/mqt/predictor/rl/actions/registry.py
@@ -51,6 +51,7 @@ def get_actions_by_pass_type() -> dict[PassType, list[Action]]:
 
 for _action in (
     *qiskit_actions.qiskit_layout_actions(),
+    *qiskit_actions.qiskit_routing_actions(),
     qiskit_actions.qiskit_mapping_action(),
     qiskit_actions.qiskit_synthesis_action(),
     qiskit_actions.qiskit_o3_action(),

--- a/src/mqt/predictor/rl/actions/tket_actions.py
+++ b/src/mqt/predictor/rl/actions/tket_actions.py
@@ -10,7 +10,9 @@
 
 from __future__ import annotations
 
+import logging
 import operator
+from functools import cache
 from typing import TYPE_CHECKING, cast
 
 from pytket import Qubit
@@ -18,9 +20,17 @@ from pytket._tket.passes import BasePass as TketBasePass  # ruff:ignore[import-p
 from pytket.architecture import Architecture
 from pytket.circuit import Node
 from pytket.extensions.qiskit import qiskit_to_tk, tk_to_qiskit
-from pytket.passes import CliffordSimp, FullPeepholeOptimise, PeepholeOptimise2Q, RemoveRedundancies, RoutingPass
-from pytket.placement import place_with_map
-from qiskit.transpiler import Layout
+from pytket.passes import (
+    CliffordSimp,
+    FullPeepholeOptimise,
+    KAKDecomposition,
+    PeepholeOptimise2Q,
+    RemoveRedundancies,
+    RoutingPass,
+)
+from pytket.placement import GraphPlacement, NoiseAwarePlacement, Placement, place_with_map
+from qiskit.transpiler import CouplingMap, Layout, PassManager, TranspileLayout
+from qiskit.transpiler.passes import ApplyLayout, EnlargeWithAncilla, FullAncillaAllocation, SetLayout
 
 from mqt.predictor.rl.actions.base import CompilationOrigin, DeferredDeviceAction, DeviceIndependentAction, PassType
 
@@ -29,10 +39,12 @@ if TYPE_CHECKING:
 
     from pytket import Circuit
     from qiskit import QuantumCircuit
-    from qiskit.passmanager.base_tasks import Task
-    from qiskit.transpiler import Target, TranspileLayout
+    from qiskit.circuit import Qubit as QiskitQubit
+    from qiskit.transpiler import Target
 
     from mqt.predictor.rl.actions.base import Action
+
+logger = logging.getLogger("mqt-predictor")
 
 
 class PreProcessTKETRoutingAfterQiskitLayout:
@@ -47,6 +59,86 @@ class PreProcessTKETRoutingAfterQiskitLayout:
         """Applies the pre-processing step to route a circuit with tket after a Qiskit Layout pass has been applied."""
         mapping = {Qubit(i): Node(i) for i in range(circuit.n_qubits)}
         place_with_map(circuit=circuit, qmap=mapping)
+
+
+@cache
+def _prepare_noise_data(device: Target) -> tuple[dict[Node, float], dict[tuple[Node, Node], float], dict[Node, float]]:
+    """Extract calibration errors for TKET's noise-aware placement."""
+    node_errors: dict[Node, float] = {}
+    link_errors: dict[tuple[Node, Node], float] = {}
+    readout_errors: dict[Node, float] = {}
+
+    for operation_name in device.operation_names:
+        for qubits, properties in device[operation_name].items():
+            if qubits is None or properties is None or properties.error is None:
+                continue
+            if len(qubits) == 1:
+                node_errors[Node(qubits[0])] = properties.error
+            elif len(qubits) == 2:
+                link_errors[Node(qubits[0]), Node(qubits[1])] = properties.error
+
+    if "measure" in device:
+        for qubits, properties in device["measure"].items():
+            if qubits is not None and len(qubits) == 1 and properties is not None and properties.error is not None:
+                readout_errors[Node(qubits[0])] = properties.error
+
+    return node_errors, link_errors, readout_errors
+
+
+def _noise_aware_placement(device: Target) -> list[Placement]:
+    node_errors, link_errors, readout_errors = _prepare_noise_data(device)
+    return [
+        NoiseAwarePlacement(
+            Architecture(list(device.build_coupling_map())),
+            node_errors=node_errors,
+            link_errors=link_errors,
+            readout_errors=readout_errors,
+            timeout=5000,
+            maximum_matches=5000,
+        )
+    ]
+
+
+def _translate_placement(
+    circuit: QuantumCircuit,
+    placement: dict[Qubit, Node],
+    action_name: str,
+    num_device_qubits: int,
+) -> Layout | None:
+    qiskit_qubits: dict[tuple[str, tuple[int, ...]], QiskitQubit] = {}
+    for qubit in circuit.qubits:
+        location = circuit.find_bit(qubit)
+        if location.registers:
+            register, register_index = location.registers[0]
+            qiskit_qubits[register.name, (register_index,)] = qubit
+        else:
+            qiskit_qubits["q", (location.index,)] = qubit
+
+    qiskit_mapping: dict[QiskitQubit, int] = {}
+    unassigned_qubits: list[QiskitQubit] = []
+    used_physical_indices: set[int] = set()
+    for tket_qubit, target_node in placement.items():
+        qiskit_qubit = qiskit_qubits.get((str(tket_qubit.reg_name), tuple(int(i) for i in tket_qubit.index)))
+        if qiskit_qubit is None:
+            logger.warning("Placement failed (%s): unknown logical qubit %s.", action_name, tket_qubit)
+            return None
+
+        if target_node.reg_name == "node" and target_node.index:
+            physical_index = int(target_node.index[0])
+            qiskit_mapping[qiskit_qubit] = physical_index
+            used_physical_indices.add(physical_index)
+        else:
+            unassigned_qubits.append(qiskit_qubit)
+
+    unassigned_qubits.extend(qubit for qubit in circuit.qubits if qubit not in qiskit_mapping)
+    unassigned_qubits = list(dict.fromkeys(unassigned_qubits))
+    remaining_indices = [index for index in range(num_device_qubits) if index not in used_physical_indices]
+    if len(remaining_indices) < len(unassigned_qubits):
+        logger.warning("Placement failed (%s): insufficient free physical qubits.", action_name)
+        return None
+
+    qiskit_mapping.update(zip(unassigned_qubits, remaining_indices, strict=False))
+    return Layout(qiskit_mapping)
 
 
 def tket_optimization_actions() -> list[Action]:
@@ -71,6 +163,15 @@ def tket_optimization_actions() -> list[Action]:
             preserves_synthesis=False,
         ),
         DeviceIndependentAction(
+            "KAKDecomposition",
+            CompilationOrigin.TKET,
+            PassType.OPT,
+            [KAKDecomposition(allow_swaps=False)],
+            preserves_layout=True,
+            preserves_routing=True,
+            preserves_synthesis=False,
+        ),
+        DeviceIndependentAction(
             "FullPeepholeOptimiseCX",
             CompilationOrigin.TKET,
             PassType.OPT,
@@ -91,19 +192,40 @@ def tket_optimization_actions() -> list[Action]:
     ]
 
 
+def tket_layout_actions() -> list[Action]:
+    """Return the TKET layout actions."""
+    return [
+        DeferredDeviceAction(
+            "GraphPlacement",
+            CompilationOrigin.TKET,
+            PassType.LAYOUT,
+            transpile_pass=lambda device: [
+                GraphPlacement(
+                    Architecture(list(device.build_coupling_map())),
+                    timeout=5000,
+                    maximum_matches=5000,
+                )
+            ],
+        ),
+        DeferredDeviceAction(
+            "NoiseAwarePlacement",
+            CompilationOrigin.TKET,
+            PassType.LAYOUT,
+            transpile_pass=_noise_aware_placement,
+        ),
+    ]
+
+
 def tket_routing_action() -> Action:
     """Returns the TKET routing action."""
     return DeferredDeviceAction(
         "RoutingPass",
         CompilationOrigin.TKET,
         PassType.ROUTING,
-        transpile_pass=lambda device: cast(
-            "list[Task]",
-            [
-                PreProcessTKETRoutingAfterQiskitLayout(),
-                RoutingPass(Architecture(list(device.build_coupling_map()))),
-            ],
-        ),
+        transpile_pass=lambda device: [
+            PreProcessTKETRoutingAfterQiskitLayout(),
+            RoutingPass(Architecture(list(device.build_coupling_map()))),
+        ],
     )
 
 
@@ -135,10 +257,43 @@ def run_tket_action(
     """Apply a TKET action and return the updated circuit and layout metadata."""
     tket_qc = qiskit_to_tk(circuit, preserve_param_uuid=True)
     if callable(action.transpile_pass):
-        factory = cast("Callable[[Target], list[Task]]", action.transpile_pass)
+        factory = cast(
+            "Callable[[Target], list[TketBasePass | PreProcessTKETRoutingAfterQiskitLayout | Placement]]",
+            action.transpile_pass,
+        )
         passes = factory(device)
     else:
-        passes = cast("list[Task]", action.transpile_pass)
+        passes = cast("list[TketBasePass | PreProcessTKETRoutingAfterQiskitLayout | Placement]", action.transpile_pass)
+
+    if action.pass_type == PassType.LAYOUT:
+        if not passes or not isinstance(passes[0], Placement):
+            msg = f"TKET layout action {action.name} did not provide a placement pass."
+            raise TypeError(msg)
+        try:
+            placement = passes[0].get_placement_map(tket_qc)
+        except (RuntimeError, TypeError, ValueError) as error:
+            logger.warning("Placement failed (%s): %s.", action.name, error)
+            return circuit, layout
+
+        qiskit_layout = _translate_placement(circuit, placement, action.name, device.num_qubits)
+        if qiskit_layout is None:
+            return circuit, layout
+        pass_manager = PassManager([
+            SetLayout(qiskit_layout),
+            FullAncillaAllocation(coupling_map=CouplingMap(device.build_coupling_map())),
+            EnlargeWithAncilla(),
+            ApplyLayout(),
+        ])
+        altered_qc = pass_manager.run(circuit)
+        applied_layout = cast("Layout", pass_manager.property_set["layout"])
+        return altered_qc, TranspileLayout(
+            initial_layout=applied_layout,
+            input_qubit_mapping=pass_manager.property_set["original_qubit_indices"],
+            final_layout=pass_manager.property_set["final_layout"],
+            _output_qubit_list=altered_qc.qubits,
+            _input_qubit_count=circuit.num_qubits,
+        )
+
     for pass_ in passes:
         assert isinstance(pass_, TketBasePass | PreProcessTKETRoutingAfterQiskitLayout)
         pass_.apply(tket_qc)
@@ -154,8 +309,10 @@ def run_tket_action(
     return altered_qc, layout
 
 
-def is_tket_action_available(*, action: Action, has_layout: bool) -> bool:
+def is_tket_action_available(*, action: Action, has_layout: bool, has_wide_operations: bool) -> bool:
     """Return whether a TKET action is available for the current layout state."""
+    if has_wide_operations and action.pass_type in {PassType.LAYOUT, PassType.ROUTING}:
+        return False
     # TKET layout/optimization actions must not run after a Qiskit layout has been set
     # (it is not clear how tket will handle the layout). TKET routing actions, however, are
     #  designed to work after a Qiskit layout via PreProcessTKETRoutingAfterQiskitLayout.

--- a/src/mqt/predictor/rl/helper.py
+++ b/src/mqt/predictor/rl/helper.py
@@ -47,14 +47,14 @@ def get_state_sample(max_qubits: int, path_training_circuits: Path, rng: Generat
     Raises:
         RuntimeError: If no quantum circuit could be read from the training circuits folder.
     """
-    file_list = list(path_training_circuits.glob("*.qasm"))
+    file_list = sorted(path_training_circuits.glob("*.qasm"))
 
     path_zip = path_training_circuits / "training_data_compilation.zip"
     if len(file_list) == 0 and path_zip.exists():
         with zipfile.ZipFile(str(path_zip), "r") as zip_ref:
             zip_ref.extractall(path_training_circuits)
 
-        file_list = list(path_training_circuits.glob("*.qasm"))
+        file_list = sorted(path_training_circuits.glob("*.qasm"))
         assert len(file_list) > 0
 
     found_suitable_qc = False

--- a/src/mqt/predictor/rl/predictorenv.py
+++ b/src/mqt/predictor/rl/predictorenv.py
@@ -71,6 +71,7 @@ class PredictorEnv(Env):
         max_steps: int | None = None,
         tracer_output_path: str | Path | None = None,
         mdp: MDPPolicy = "v3",
+        stochastic_action_trials: int = 20,
     ) -> None:
         """Initializes the PredictorEnv object.
 
@@ -83,6 +84,8 @@ class PredictorEnv(Env):
             mdp: The MDP transition policy. ``v2`` is the original MQT Predictor
                 strategy. ``v3`` is the default and is permissive before layout while
                 preserving the established compilation structure afterwards.
+            stochastic_action_trials: Number of attempts used to select the best
+                result from a stochastic action.
 
         Raises:
             ValueError: If ``mdp`` is unsupported, if the reward function is
@@ -96,10 +99,14 @@ class PredictorEnv(Env):
         if mdp not in MDP_POLICIES:
             msg = f"Unsupported MDP policy: {mdp}."
             raise ValueError(msg)
+        if stochastic_action_trials < 1:
+            msg = "stochastic_action_trials must be at least one."
+            raise ValueError(msg)
 
         self.path_training_circuits = path_training_circuits or get_path_training_circuits()
         self.max_steps = max_steps
         self.mdp = mdp
+        self.stochastic_action_trials = stochastic_action_trials
 
         self.action_set = {}
         self.actions_synthesis_indices = []
@@ -549,6 +556,8 @@ class PredictorEnv(Env):
                 device=self.device,
                 layout=self.layout,
                 input_qubit_count=self.num_qubits_uncompiled_circuit,
+                stochastic_action_trials=self.stochastic_action_trials,
+                score=self._score_circuit if action.stochastic else None,
             )
         elif action.origin == CompilationOrigin.TKET:
             altered_qc, self.layout = run_tket_action(
@@ -569,6 +578,19 @@ class PredictorEnv(Env):
             raise ValueError(msg)
 
         return altered_qc
+
+    def _score_circuit(self, circuit: QuantumCircuit) -> float:
+        """Calculate the configured figure of merit for an action candidate."""
+        if self.reward_function == "expected_fidelity":
+            return expected_fidelity(circuit, self.device)
+        if self.reward_function == "estimated_success_probability":
+            return estimated_success_probability(circuit, self.device)
+        if self.reward_function == "estimated_hellinger_distance":
+            return estimated_hellinger_distance(circuit, self.device, self.hellinger_model)
+        if self.reward_function == "critical_depth":
+            return crit_depth(circuit)
+        msg = f"No implementation for reward function {self.reward_function}."
+        raise NotImplementedError(msg)
 
     def is_circuit_laid_out(self, circuit: QuantumCircuit, layout: TranspileLayout | Layout) -> bool:
         """True if every logical qubit in the circuit has a physical assignment."""

--- a/src/mqt/predictor/rl/predictorenv.py
+++ b/src/mqt/predictor/rl/predictorenv.py
@@ -186,7 +186,6 @@ class PredictorEnv(Env):
         self.layout: TranspileLayout | None = None
 
         self.has_parameterized_gates = False
-        self.rng = np.random.default_rng(10)
 
         operation_spaces = {
             operation: Box(low=0, high=1, shape=(1,), dtype=np.float32) for operation in OBSERVATION_OPERATIONS
@@ -428,7 +427,11 @@ class PredictorEnv(Env):
             self.filename = str(qc)
             current_circuit_name = Path(str(qc)).stem
         else:
-            self.state, self.filename = get_state_sample(self.device.num_qubits, self.path_training_circuits, self.rng)
+            self.state, self.filename = get_state_sample(
+                self.device.num_qubits,
+                self.path_training_circuits,
+                self.np_random,
+            )
             current_circuit_name = Path(self.filename).stem
 
         self.action_space = Discrete(len(self.action_set.keys()))

--- a/src/mqt/predictor/rl/predictorenv.py
+++ b/src/mqt/predictor/rl/predictorenv.py
@@ -28,7 +28,9 @@ from gymnasium import Env
 from gymnasium.spaces import Box, Dict, Discrete
 from joblib import load
 from qiskit import QuantumCircuit
-from qiskit.transpiler import CouplingMap, TranspileLayout
+from qiskit.circuit import StandardEquivalenceLibrary
+from qiskit.transpiler import CouplingMap, PassManager, TranspileLayout
+from qiskit.transpiler.passes import BasisTranslator
 
 from mqt.predictor.hellinger import get_hellinger_model_path
 from mqt.predictor.reward import (
@@ -581,14 +583,17 @@ class PredictorEnv(Env):
 
     def _score_circuit(self, circuit: QuantumCircuit) -> float:
         """Calculate the configured figure of merit for an action candidate."""
+        scoring_circuit = PassManager(
+            [BasisTranslator(StandardEquivalenceLibrary, target_basis=self.device.operation_names)]
+        ).run(circuit.copy())
         if self.reward_function == "expected_fidelity":
-            return expected_fidelity(circuit, self.device)
+            return expected_fidelity(scoring_circuit, self.device)
         if self.reward_function == "estimated_success_probability":
-            return estimated_success_probability(circuit, self.device)
+            return estimated_success_probability(scoring_circuit, self.device)
         if self.reward_function == "estimated_hellinger_distance":
-            return estimated_hellinger_distance(circuit, self.device, self.hellinger_model)
+            return estimated_hellinger_distance(scoring_circuit, self.device, self.hellinger_model)
         if self.reward_function == "critical_depth":
-            return crit_depth(circuit)
+            return crit_depth(scoring_circuit)
         msg = f"No implementation for reward function {self.reward_function}."
         raise NotImplementedError(msg)
 

--- a/src/mqt/predictor/rl/predictorenv.py
+++ b/src/mqt/predictor/rl/predictorenv.py
@@ -515,7 +515,7 @@ class PredictorEnv(Env):
                 action_mask.append(True)
                 continue
             if action.origin == CompilationOrigin.QISKIT:
-                action_mask.append(is_qiskit_action_available(action, self.device))
+                action_mask.append(is_qiskit_action_available(action, self.state, self.device))
             elif action.origin == CompilationOrigin.TKET:
                 action_mask.append(is_tket_action_available(action=action, has_layout=has_layout))
             elif action.origin == CompilationOrigin.BQSKIT:

--- a/src/mqt/predictor/rl/predictorenv.py
+++ b/src/mqt/predictor/rl/predictorenv.py
@@ -583,9 +583,9 @@ class PredictorEnv(Env):
 
     def _score_circuit(self, circuit: QuantumCircuit) -> float:
         """Calculate the configured figure of merit for an action candidate."""
-        scoring_circuit = PassManager(
-            [BasisTranslator(StandardEquivalenceLibrary, target_basis=self.device.operation_names)]
-        ).run(circuit.copy())
+        scoring_circuit = PassManager([
+            BasisTranslator(StandardEquivalenceLibrary, target_basis=self.device.operation_names)
+        ]).run(circuit.copy())
         if self.reward_function == "expected_fidelity":
             return expected_fidelity(scoring_circuit, self.device)
         if self.reward_function == "estimated_success_probability":

--- a/src/mqt/predictor/rl/predictorenv.py
+++ b/src/mqt/predictor/rl/predictorenv.py
@@ -11,6 +11,7 @@
 from __future__ import annotations
 
 import logging
+from math import isclose
 import re
 import time
 import warnings
@@ -74,6 +75,9 @@ class PredictorEnv(Env):
         tracer_output_path: str | Path | None = None,
         mdp: MDPPolicy = "v3",
         stochastic_action_trials: int = 20,
+        intermediate_reward: bool = True,
+        reward_scale: float = 1.0,
+        no_effect_penalty: float = -0.001,
     ) -> None:
         """Initializes the PredictorEnv object.
 
@@ -88,6 +92,11 @@ class PredictorEnv(Env):
                 preserving the established compilation structure afterwards.
             stochastic_action_trials: Number of attempts used to select the best
                 result from a stochastic action.
+            intermediate_reward: Whether to reward changes to the figure of merit
+                before termination.
+            reward_scale: Multiplier applied to intermediate reward changes.
+            no_effect_penalty: Reward for optimization actions that do not improve
+                the figure of merit.
 
         Raises:
             ValueError: If ``mdp`` is unsupported, if the reward function is
@@ -109,6 +118,9 @@ class PredictorEnv(Env):
         self.max_steps = max_steps
         self.mdp = mdp
         self.stochastic_action_trials = stochastic_action_trials
+        self.intermediate_reward = intermediate_reward
+        self.reward_scale = reward_scale
+        self.no_effect_penalty = no_effect_penalty
 
         self.action_set = {}
         self.actions_synthesis_indices = []
@@ -299,6 +311,11 @@ class PredictorEnv(Env):
         start_time = time.perf_counter()
         try:
             self.used_actions.append(action_name)
+            previous_reward = (
+                self._get_stepwise_reward()
+                if self.intermediate_reward and action != self.action_terminate_index
+                else None
+            )
             altered_qc = self.apply_action(action)
             action_duration = time.perf_counter() - start_time
         except Exception as exc:  # ruff:ignore[blind-except]
@@ -341,6 +358,9 @@ class PredictorEnv(Env):
         if action == self.action_terminate_index:
             reward_val = self.calculate_reward()
             done = True
+        elif previous_reward is not None:
+            reward_val = self._calculate_intermediate_reward(action, previous_reward)
+            done = False
         else:
             reward_val = 0
             done = False
@@ -396,6 +416,56 @@ class PredictorEnv(Env):
     def calculate_reward(self) -> float:
         """Calculates and returns the reward for the current state."""
         return self.get_fom(self.reward_function)
+
+    def _get_stepwise_reward(self) -> tuple[float, str]:
+        """Return the current reward and whether it is exact or approximate."""
+        if self.reward_function not in {"expected_fidelity", "estimated_success_probability"}:
+            return 0.0, "unavailable"
+
+        if self._current_synthesized and self._current_laid_out and self._current_routed:
+            return self.calculate_reward(), "exact"
+        return self._approximate_reward(), "approximate"
+
+    def _approximate_reward(self) -> float:
+        """Estimate a reward from the average error of translated native gates."""
+        circuit = PassManager(
+            [BasisTranslator(StandardEquivalenceLibrary, target_basis=self.device.operation_names)]
+        ).run(self.state.copy())
+        reward = 1.0
+
+        for instruction in circuit.data:
+            gate_name = instruction.operation.name
+            if gate_name in {"barrier", "measure"}:
+                continue
+
+            try:
+                properties = self.device[gate_name].values()
+            except KeyError:
+                return 0.0
+
+            errors = [
+                property.error for property in properties if property is not None and property.error is not None
+            ]
+            if not errors:
+                return 0.0
+            reward *= 1 - float(np.mean(errors))
+
+        return reward
+
+    def _calculate_intermediate_reward(self, action: int, previous_reward: tuple[float, str]) -> float:
+        """Calculate the shaped reward for a non-terminal action."""
+        previous_value, previous_kind = previous_reward
+        current_value, current_kind = self._get_stepwise_reward()
+        if previous_kind != current_kind:
+            return 0.0
+
+        delta = current_value - previous_value
+        if not isclose(delta, 0.0, abs_tol=1e-12):
+            return self.reward_scale * delta
+
+        if self.action_set[action].pass_type in {PassType.OPT, PassType.FINAL_OPT}:
+            return self.no_effect_penalty
+        return 0.0
 
     def render(self) -> None:
         """Renders the current state."""

--- a/src/mqt/predictor/rl/predictorenv.py
+++ b/src/mqt/predictor/rl/predictorenv.py
@@ -443,7 +443,11 @@ class PredictorEnv(Env):
             except KeyError:
                 return 0.0
 
-            errors = [property.error for property in properties if property is not None and property.error is not None]
+            errors = [
+                instruction_property.error
+                for instruction_property in properties
+                if instruction_property is not None and instruction_property.error is not None
+            ]
             if not errors:
                 return 0.0
             reward *= 1 - float(np.mean(errors))

--- a/src/mqt/predictor/rl/predictorenv.py
+++ b/src/mqt/predictor/rl/predictorenv.py
@@ -11,10 +11,10 @@
 from __future__ import annotations
 
 import logging
-from math import isclose
 import re
 import time
 import warnings
+from math import isclose
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Literal, get_args
 
@@ -428,9 +428,9 @@ class PredictorEnv(Env):
 
     def _approximate_reward(self) -> float:
         """Estimate a reward from the average error of translated native gates."""
-        circuit = PassManager(
-            [BasisTranslator(StandardEquivalenceLibrary, target_basis=self.device.operation_names)]
-        ).run(self.state.copy())
+        circuit = PassManager([
+            BasisTranslator(StandardEquivalenceLibrary, target_basis=self.device.operation_names)
+        ]).run(self.state.copy())
         reward = 1.0
 
         for instruction in circuit.data:
@@ -443,9 +443,7 @@ class PredictorEnv(Env):
             except KeyError:
                 return 0.0
 
-            errors = [
-                property.error for property in properties if property is not None and property.error is not None
-            ]
+            errors = [property.error for property in properties if property is not None and property.error is not None]
             if not errors:
                 return 0.0
             reward *= 1 - float(np.mean(errors))

--- a/src/mqt/predictor/rl/predictorenv.py
+++ b/src/mqt/predictor/rl/predictorenv.py
@@ -502,6 +502,7 @@ class PredictorEnv(Env):
             A dense boolean mask ordered like ``self.action_set``.
         """
         has_layout = self.layout is not None
+        has_wide_operations = any(len(instruction.qubits) > 2 for instruction in self.state.data)
         valid_action_indices = set(self.valid_actions)
         action_mask: list[bool] = []
 
@@ -517,7 +518,13 @@ class PredictorEnv(Env):
             if action.origin == CompilationOrigin.QISKIT:
                 action_mask.append(is_qiskit_action_available(action, self.device))
             elif action.origin == CompilationOrigin.TKET:
-                action_mask.append(is_tket_action_available(action=action, has_layout=has_layout))
+                action_mask.append(
+                    is_tket_action_available(
+                        action=action,
+                        has_layout=has_layout,
+                        has_wide_operations=has_wide_operations,
+                    )
+                )
             elif action.origin == CompilationOrigin.BQSKIT:
                 action_mask.append(
                     is_bqskit_action_available(

--- a/src/mqt/predictor/rl/predictorenv.py
+++ b/src/mqt/predictor/rl/predictorenv.py
@@ -515,7 +515,7 @@ class PredictorEnv(Env):
                 action_mask.append(True)
                 continue
             if action.origin == CompilationOrigin.QISKIT:
-                action_mask.append(is_qiskit_action_available(action, self.state, self.device))
+                action_mask.append(is_qiskit_action_available(action, self.device))
             elif action.origin == CompilationOrigin.TKET:
                 action_mask.append(is_tket_action_available(action=action, has_layout=has_layout))
             elif action.origin == CompilationOrigin.BQSKIT:

--- a/tests/compilation/test_integration_further_SDKs.py
+++ b/tests/compilation/test_integration_further_SDKs.py
@@ -10,13 +10,12 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
-
 import pytest
 from mqt.bench.targets import get_device
 from qiskit import QuantumCircuit
 from qiskit.circuit import StandardEquivalenceLibrary
-from qiskit.transpiler import PassManager, TranspileLayout
+from qiskit.circuit.library import CXGate, HGate
+from qiskit.transpiler import PassManager, Target, TranspileLayout
 from qiskit.transpiler.passes import (
     ApplyLayout,
     BasisTranslator,
@@ -28,9 +27,6 @@ from qiskit.transpiler.passes import (
 
 from mqt.predictor.rl.actions import CompilationOrigin, PassType
 from mqt.predictor.rl.predictorenv import PredictorEnv
-
-if TYPE_CHECKING:
-    from qiskit.transpiler import Target
 
 
 def _setup_env(env: PredictorEnv, circuit: QuantumCircuit, layout: TranspileLayout | None, n_qubits: int) -> None:
@@ -126,6 +122,16 @@ def env(target: Target) -> PredictorEnv:
     return PredictorEnv(device=target, reward_function="expected_fidelity")
 
 
+@pytest.fixture
+def directional_env() -> PredictorEnv:
+    """Create an environment for direction-sensitive routing actions."""
+    target = Target(num_qubits=2, description="directional test target")
+    target.add_instruction(HGate(), {(0,): None, (1,): None})
+    target.add_instruction(CXGate(), {(0, 1): None})
+    with pytest.warns(UserWarning, match="uni-directional"):
+        return PredictorEnv(device=target, reward_function="expected_fidelity")
+
+
 def test_synthesis_actions_produce_native_gates(
     simple_circuit: QuantumCircuit,
     env: PredictorEnv,
@@ -169,12 +175,7 @@ def test_layout_actions_establish_layout(
     for idx, action in env.action_set.items():
         if action.pass_type != PassType.LAYOUT:
             continue
-        circuit = synthesized
-        if action.name == "ElidePermutations":
-            circuit = QuantumCircuit(3)
-            circuit.swap(0, 1)
-            circuit.x(0)
-        _setup_env(env, circuit, None, circuit.num_qubits)
+        _setup_env(env, synthesized, None, synthesized.num_qubits)
         if not _is_available(env, idx):
             continue
         compiled = env.apply_action(idx)
@@ -186,9 +187,6 @@ def test_layout_actions_establish_layout(
             f"{action.name} on {env.device.description} VIOLATED INVARIANT: "
             f"did not establish valid layout. Layout: {env.layout}"
         )
-        if action.name == "ElidePermutations":
-            assert "swap" not in compiled.count_ops()
-            assert env.layout.final_index_layout() == [1, 0, 2]
 
     assert applied_actions > 0
 
@@ -229,38 +227,48 @@ def test_mapping_actions_establish_layout_and_route(
 def test_routing_actions_route_circuit(
     simple_circuit: QuantumCircuit,
     env: PredictorEnv,
+    directional_env: PredictorEnv,
 ) -> None:
     """Invariant: every routing action produces a circuit where all 2-qubit gates respect the coupling map."""
-    coupling_map = env.device.build_coupling_map()
-    applied_actions = 0
-
     for idx, action in env.action_set.items():
         if action.pass_type != PassType.ROUTING:
             continue
+
         qc_laid_out, layout = _lay_out(simple_circuit, env.device)
-        n_qubits = qc_laid_out.num_qubits
-        _setup_env(env, qc_laid_out, layout, n_qubits)
-        if not _is_available(env, idx):
-            continue
-        routed = env.apply_action(idx)
-        applied_actions += 1
-        assert env.is_circuit_routed(routed, coupling_map), (
-            f"{action.name} on {env.device.description} VIOLATED INVARIANT: circuit not properly routed after action"
+        directional_circuit = QuantumCircuit(2)
+        directional_circuit.cx(1, 0)
+        directional_laid_out, directional_layout = _lay_out(directional_circuit, directional_env.device)
+        test_cases = (
+            (env, qc_laid_out, layout),
+            (directional_env, directional_laid_out, directional_layout),
+        )
+
+        for action_env, circuit, action_layout in test_cases:
+            n_qubits = circuit.num_qubits
+            _setup_env(action_env, circuit, action_layout, n_qubits)
+            if _is_available(action_env, idx):
+                routed = action_env.apply_action(idx)
+                break
+        else:
+            pytest.fail(f"{action.name} was unavailable for all routing test cases")
+
+        coupling_map = action_env.device.build_coupling_map()
+        assert action_env.is_circuit_routed(routed, coupling_map), (
+            f"{action.name} on {action_env.device.description} VIOLATED INVARIANT: "
+            "circuit not properly routed after action"
         )
         # Check BQSKit routing translates its output permutation into Qiskit layout bookkeeping correctly.
         if action.origin == CompilationOrigin.BQSKIT:
-            assert env.layout is not None
-            assert env.layout.final_layout is not None
-            assert set(env.layout.final_layout.get_virtual_bits()).issubset(routed.qubits)
-            assert env.layout._output_qubit_list == routed.qubits  # ruff: ignore[private-member-access]
+            assert action_env.layout is not None
+            assert action_env.layout.final_layout is not None
+            assert set(action_env.layout.final_layout.get_virtual_bits()).issubset(routed.qubits)
+            assert action_env.layout._output_qubit_list == routed.qubits  # ruff: ignore[private-member-access]
 
-            _setup_env(env, routed, env.layout, n_qubits)
-            rerouted = env.apply_action(idx)
-            assert env.layout.final_layout is not None
-            assert set(env.layout.final_layout.get_virtual_bits()).issubset(rerouted.qubits)
-            assert env.layout._output_qubit_list == rerouted.qubits  # ruff: ignore[private-member-access]
-
-    assert applied_actions > 0
+            _setup_env(action_env, routed, action_env.layout, n_qubits)
+            rerouted = action_env.apply_action(idx)
+            assert action_env.layout.final_layout is not None
+            assert set(action_env.layout.final_layout.get_virtual_bits()).issubset(rerouted.qubits)
+            assert action_env.layout._output_qubit_list == rerouted.qubits  # ruff: ignore[private-member-access]
 
 
 def test_optimization_actions_preserve_invariants(
@@ -316,10 +324,3 @@ def test_optimization_actions_preserve_invariants(
                     f"Device native gates: {env.device.operation_names}. "
                     f"Circuit gates: {set(compiled.count_ops().keys())}"
                 )
-
-        if action.name == "OptimizeCliffords":
-            clifford_circuit = QuantumCircuit(1)
-            clifford_circuit.h(0)
-            clifford_circuit.h(0)
-            _setup_env(env, clifford_circuit, None, clifford_circuit.num_qubits)
-            assert not env.apply_action(idx).data

--- a/tests/compilation/test_integration_further_SDKs.py
+++ b/tests/compilation/test_integration_further_SDKs.py
@@ -10,13 +10,12 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
-
 import pytest
 from mqt.bench.targets import get_device
 from qiskit import QuantumCircuit
 from qiskit.circuit import StandardEquivalenceLibrary
-from qiskit.transpiler import PassManager, TranspileLayout
+from qiskit.circuit.library import CXGate, HGate
+from qiskit.transpiler import PassManager, Target, TranspileLayout
 from qiskit.transpiler.passes import (
     ApplyLayout,
     BasisTranslator,
@@ -28,9 +27,6 @@ from qiskit.transpiler.passes import (
 
 from mqt.predictor.rl.actions import CompilationOrigin, PassType
 from mqt.predictor.rl.predictorenv import PredictorEnv
-
-if TYPE_CHECKING:
-    from qiskit.transpiler import Target
 
 
 def _setup_env(env: PredictorEnv, circuit: QuantumCircuit, layout: TranspileLayout | None, n_qubits: int) -> None:
@@ -44,6 +40,11 @@ def _is_available(env: PredictorEnv, idx: int) -> bool:
     """Return whether action idx is structurally and SDK-valid for the current env state."""
     env.valid_actions = env.determine_valid_actions_for_state()
     return env.action_masks()[idx]
+
+
+def _action_index(env: PredictorEnv, name: str) -> int:
+    """Return the index of an action with the given name."""
+    return next(idx for idx, action in env.action_set.items() if action.name == name)
 
 
 def _lay_out(circuit: QuantumCircuit, target: Target) -> tuple[QuantumCircuit, TranspileLayout]:
@@ -124,6 +125,69 @@ def simple_circuit() -> QuantumCircuit:
 def env(target: Target) -> PredictorEnv:
     """Create a PredictorEnv for state-based invariant checking."""
     return PredictorEnv(device=target, reward_function="expected_fidelity")
+
+
+def test_requested_qiskit_passes_are_registered(env: PredictorEnv) -> None:
+    """All requested individual Qiskit passes are exposed as RL actions."""
+    action_names = {action.name for action in env.action_set.values()}
+    assert {
+        "BasicSwap",
+        "ElidePermutations",
+        "GateDirection",
+        "LookaheadSwap",
+        "Optimize1qGatesSimpleCommutation",
+        "RemoveIdentityEquivalent",
+        "TrivialLayout",
+    } <= action_names
+
+
+def test_elide_permutations_tracks_output_permutation(env: PredictorEnv) -> None:
+    """Eliding a SWAP keeps its output permutation in the established layout."""
+    circuit = QuantumCircuit(3)
+    circuit.swap(0, 1)
+    circuit.x(0)
+    _setup_env(env, circuit, None, circuit.num_qubits)
+
+    compiled = env.apply_action(_action_index(env, "ElidePermutations"))
+
+    assert "swap" not in compiled.count_ops()
+    assert [
+        (instruction.operation.name, compiled.find_bit(instruction.qubits[0]).index) for instruction in compiled.data
+    ] == [("x", 1)]
+    assert env.layout is not None
+    assert env.layout.final_index_layout() == [1, 0, 2]
+
+
+def test_gate_direction_routes_adjacent_directional_gate() -> None:
+    """GateDirection is available once only edge direction remains to be fixed."""
+    directional_target = Target(num_qubits=2, description="directional test target")
+    directional_target.add_instruction(HGate(), {(0,): None, (1,): None})
+    directional_target.add_instruction(CXGate(), {(0, 1): None})
+    with pytest.warns(UserWarning, match="uni-directional"):
+        directional_env = PredictorEnv(device=directional_target, reward_function="expected_fidelity")
+
+    circuit = QuantumCircuit(2)
+    circuit.cx(1, 0)
+    laid_out, layout = _lay_out(circuit, directional_target)
+    _setup_env(directional_env, laid_out, layout, circuit.num_qubits)
+    action_index = _action_index(directional_env, "GateDirection")
+
+    assert _is_available(directional_env, action_index)
+    compiled = directional_env.apply_action(action_index)
+
+    assert directional_env.is_circuit_routed(compiled, directional_target.build_coupling_map())
+
+
+def test_optimize_cliffords_collects_standard_clifford_gates(env: PredictorEnv) -> None:
+    """OptimizeCliffords first collects ordinary gates and decomposes its result."""
+    circuit = QuantumCircuit(1)
+    circuit.h(0)
+    circuit.h(0)
+    _setup_env(env, circuit, None, circuit.num_qubits)
+
+    compiled = env.apply_action(_action_index(env, "OptimizeCliffords"))
+
+    assert not compiled.data
 
 
 def test_synthesis_actions_produce_native_gates(

--- a/tests/compilation/test_integration_further_SDKs.py
+++ b/tests/compilation/test_integration_further_SDKs.py
@@ -10,12 +10,13 @@
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 import pytest
 from mqt.bench.targets import get_device
 from qiskit import QuantumCircuit
 from qiskit.circuit import StandardEquivalenceLibrary
-from qiskit.circuit.library import CXGate, HGate
-from qiskit.transpiler import PassManager, Target, TranspileLayout
+from qiskit.transpiler import PassManager, TranspileLayout
 from qiskit.transpiler.passes import (
     ApplyLayout,
     BasisTranslator,
@@ -27,6 +28,9 @@ from qiskit.transpiler.passes import (
 
 from mqt.predictor.rl.actions import CompilationOrigin, PassType
 from mqt.predictor.rl.predictorenv import PredictorEnv
+
+if TYPE_CHECKING:
+    from qiskit.transpiler import Target
 
 
 def _setup_env(env: PredictorEnv, circuit: QuantumCircuit, layout: TranspileLayout | None, n_qubits: int) -> None:
@@ -40,11 +44,6 @@ def _is_available(env: PredictorEnv, idx: int) -> bool:
     """Return whether action idx is structurally and SDK-valid for the current env state."""
     env.valid_actions = env.determine_valid_actions_for_state()
     return env.action_masks()[idx]
-
-
-def _action_index(env: PredictorEnv, name: str) -> int:
-    """Return the index of an action with the given name."""
-    return next(idx for idx, action in env.action_set.items() if action.name == name)
 
 
 def _lay_out(circuit: QuantumCircuit, target: Target) -> tuple[QuantumCircuit, TranspileLayout]:
@@ -127,69 +126,6 @@ def env(target: Target) -> PredictorEnv:
     return PredictorEnv(device=target, reward_function="expected_fidelity")
 
 
-def test_requested_qiskit_passes_are_registered(env: PredictorEnv) -> None:
-    """All requested individual Qiskit passes are exposed as RL actions."""
-    action_names = {action.name for action in env.action_set.values()}
-    assert {
-        "BasicSwap",
-        "ElidePermutations",
-        "GateDirection",
-        "LookaheadSwap",
-        "Optimize1qGatesSimpleCommutation",
-        "RemoveIdentityEquivalent",
-        "TrivialLayout",
-    } <= action_names
-
-
-def test_elide_permutations_tracks_output_permutation(env: PredictorEnv) -> None:
-    """Eliding a SWAP keeps its output permutation in the established layout."""
-    circuit = QuantumCircuit(3)
-    circuit.swap(0, 1)
-    circuit.x(0)
-    _setup_env(env, circuit, None, circuit.num_qubits)
-
-    compiled = env.apply_action(_action_index(env, "ElidePermutations"))
-
-    assert "swap" not in compiled.count_ops()
-    assert [
-        (instruction.operation.name, compiled.find_bit(instruction.qubits[0]).index) for instruction in compiled.data
-    ] == [("x", 1)]
-    assert env.layout is not None
-    assert env.layout.final_index_layout() == [1, 0, 2]
-
-
-def test_gate_direction_routes_adjacent_directional_gate() -> None:
-    """GateDirection is available once only edge direction remains to be fixed."""
-    directional_target = Target(num_qubits=2, description="directional test target")
-    directional_target.add_instruction(HGate(), {(0,): None, (1,): None})
-    directional_target.add_instruction(CXGate(), {(0, 1): None})
-    with pytest.warns(UserWarning, match="uni-directional"):
-        directional_env = PredictorEnv(device=directional_target, reward_function="expected_fidelity")
-
-    circuit = QuantumCircuit(2)
-    circuit.cx(1, 0)
-    laid_out, layout = _lay_out(circuit, directional_target)
-    _setup_env(directional_env, laid_out, layout, circuit.num_qubits)
-    action_index = _action_index(directional_env, "GateDirection")
-
-    assert _is_available(directional_env, action_index)
-    compiled = directional_env.apply_action(action_index)
-
-    assert directional_env.is_circuit_routed(compiled, directional_target.build_coupling_map())
-
-
-def test_optimize_cliffords_collects_standard_clifford_gates(env: PredictorEnv) -> None:
-    """OptimizeCliffords first collects ordinary gates and decomposes its result."""
-    circuit = QuantumCircuit(1)
-    circuit.h(0)
-    circuit.h(0)
-    _setup_env(env, circuit, None, circuit.num_qubits)
-
-    compiled = env.apply_action(_action_index(env, "OptimizeCliffords"))
-
-    assert not compiled.data
-
-
 def test_synthesis_actions_produce_native_gates(
     simple_circuit: QuantumCircuit,
     env: PredictorEnv,
@@ -233,7 +169,12 @@ def test_layout_actions_establish_layout(
     for idx, action in env.action_set.items():
         if action.pass_type != PassType.LAYOUT:
             continue
-        _setup_env(env, synthesized, None, synthesized.num_qubits)
+        circuit = synthesized
+        if action.name == "ElidePermutations":
+            circuit = QuantumCircuit(3)
+            circuit.swap(0, 1)
+            circuit.x(0)
+        _setup_env(env, circuit, None, circuit.num_qubits)
         if not _is_available(env, idx):
             continue
         compiled = env.apply_action(idx)
@@ -245,6 +186,9 @@ def test_layout_actions_establish_layout(
             f"{action.name} on {env.device.description} VIOLATED INVARIANT: "
             f"did not establish valid layout. Layout: {env.layout}"
         )
+        if action.name == "ElidePermutations":
+            assert "swap" not in compiled.count_ops()
+            assert env.layout.final_index_layout() == [1, 0, 2]
 
     assert applied_actions > 0
 
@@ -372,3 +316,10 @@ def test_optimization_actions_preserve_invariants(
                     f"Device native gates: {env.device.operation_names}. "
                     f"Circuit gates: {set(compiled.count_ops().keys())}"
                 )
+
+        if action.name == "OptimizeCliffords":
+            clifford_circuit = QuantumCircuit(1)
+            clifford_circuit.h(0)
+            clifford_circuit.h(0)
+            _setup_env(env, clifford_circuit, None, clifford_circuit.num_qubits)
+            assert not env.apply_action(idx).data

--- a/tests/compilation/test_integration_further_SDKs.py
+++ b/tests/compilation/test_integration_further_SDKs.py
@@ -10,12 +10,13 @@
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 import pytest
 from mqt.bench.targets import get_device
 from qiskit import QuantumCircuit
 from qiskit.circuit import StandardEquivalenceLibrary
-from qiskit.circuit.library import CXGate, HGate
-from qiskit.transpiler import PassManager, Target, TranspileLayout
+from qiskit.transpiler import PassManager, TranspileLayout
 from qiskit.transpiler.passes import (
     ApplyLayout,
     BasisTranslator,
@@ -27,6 +28,9 @@ from qiskit.transpiler.passes import (
 
 from mqt.predictor.rl.actions import CompilationOrigin, PassType
 from mqt.predictor.rl.predictorenv import PredictorEnv
+
+if TYPE_CHECKING:
+    from qiskit.transpiler import Target
 
 
 def _setup_env(env: PredictorEnv, circuit: QuantumCircuit, layout: TranspileLayout | None, n_qubits: int) -> None:
@@ -120,16 +124,6 @@ def simple_circuit() -> QuantumCircuit:
 def env(target: Target) -> PredictorEnv:
     """Create a PredictorEnv for state-based invariant checking."""
     return PredictorEnv(device=target, reward_function="expected_fidelity")
-
-
-@pytest.fixture
-def directional_env() -> PredictorEnv:
-    """Create an environment for direction-sensitive routing actions."""
-    target = Target(num_qubits=2, description="directional test target")
-    target.add_instruction(HGate(), {(0,): None, (1,): None})
-    target.add_instruction(CXGate(), {(0, 1): None})
-    with pytest.warns(UserWarning, match="uni-directional"):
-        return PredictorEnv(device=target, reward_function="expected_fidelity")
 
 
 def test_synthesis_actions_produce_native_gates(
@@ -227,48 +221,38 @@ def test_mapping_actions_establish_layout_and_route(
 def test_routing_actions_route_circuit(
     simple_circuit: QuantumCircuit,
     env: PredictorEnv,
-    directional_env: PredictorEnv,
 ) -> None:
     """Invariant: every routing action produces a circuit where all 2-qubit gates respect the coupling map."""
+    coupling_map = env.device.build_coupling_map()
+    applied_actions = 0
+
     for idx, action in env.action_set.items():
         if action.pass_type != PassType.ROUTING:
             continue
-
         qc_laid_out, layout = _lay_out(simple_circuit, env.device)
-        directional_circuit = QuantumCircuit(2)
-        directional_circuit.cx(1, 0)
-        directional_laid_out, directional_layout = _lay_out(directional_circuit, directional_env.device)
-        test_cases = (
-            (env, qc_laid_out, layout),
-            (directional_env, directional_laid_out, directional_layout),
-        )
-
-        for action_env, circuit, action_layout in test_cases:
-            n_qubits = circuit.num_qubits
-            _setup_env(action_env, circuit, action_layout, n_qubits)
-            if _is_available(action_env, idx):
-                routed = action_env.apply_action(idx)
-                break
-        else:
-            pytest.fail(f"{action.name} was unavailable for all routing test cases")
-
-        coupling_map = action_env.device.build_coupling_map()
-        assert action_env.is_circuit_routed(routed, coupling_map), (
-            f"{action.name} on {action_env.device.description} VIOLATED INVARIANT: "
-            "circuit not properly routed after action"
+        n_qubits = qc_laid_out.num_qubits
+        _setup_env(env, qc_laid_out, layout, n_qubits)
+        if not _is_available(env, idx):
+            continue
+        routed = env.apply_action(idx)
+        applied_actions += 1
+        assert env.is_circuit_routed(routed, coupling_map), (
+            f"{action.name} on {env.device.description} VIOLATED INVARIANT: circuit not properly routed after action"
         )
         # Check BQSKit routing translates its output permutation into Qiskit layout bookkeeping correctly.
         if action.origin == CompilationOrigin.BQSKIT:
-            assert action_env.layout is not None
-            assert action_env.layout.final_layout is not None
-            assert set(action_env.layout.final_layout.get_virtual_bits()).issubset(routed.qubits)
-            assert action_env.layout._output_qubit_list == routed.qubits  # ruff: ignore[private-member-access]
+            assert env.layout is not None
+            assert env.layout.final_layout is not None
+            assert set(env.layout.final_layout.get_virtual_bits()).issubset(routed.qubits)
+            assert env.layout._output_qubit_list == routed.qubits  # ruff: ignore[private-member-access]
 
-            _setup_env(action_env, routed, action_env.layout, n_qubits)
-            rerouted = action_env.apply_action(idx)
-            assert action_env.layout.final_layout is not None
-            assert set(action_env.layout.final_layout.get_virtual_bits()).issubset(rerouted.qubits)
-            assert action_env.layout._output_qubit_list == rerouted.qubits  # ruff: ignore[private-member-access]
+            _setup_env(env, routed, env.layout, n_qubits)
+            rerouted = env.apply_action(idx)
+            assert env.layout.final_layout is not None
+            assert set(env.layout.final_layout.get_virtual_bits()).issubset(rerouted.qubits)
+            assert env.layout._output_qubit_list == rerouted.qubits  # ruff: ignore[private-member-access]
+
+    assert applied_actions > 0
 
 
 def test_optimization_actions_preserve_invariants(

--- a/tests/compilation/test_predictor_rl.py
+++ b/tests/compilation/test_predictor_rl.py
@@ -149,15 +149,32 @@ def test_qcompile_with_false_input() -> None:
         rl_compile(qc, device=None, figure_of_merit="expected_fidelity")
 
 
-def test_warning_for_unidirectional_device() -> None:
-    """Test the warning for a unidirectional device."""
+def test_unidirectional_device_warning_and_gate_direction() -> None:
+    """Test warning and gate-direction routing for a unidirectional device."""
     target = Target()
     target.add_instruction(CXGate(), {(0, 1): InstructionProperties()})
     target.description = "uni-directional device"
 
     msg = "The connectivity of the device 'uni-directional device' is uni-directional and MQT Predictor might return a compiled circuit that assumes bi-directionality."
     with pytest.warns(UserWarning, match=re.escape(msg)):
-        Predictor(figure_of_merit="expected_fidelity", device=target)
+        predictor = Predictor(figure_of_merit="expected_fidelity", device=target)
+
+    env = predictor.env
+    qc = QuantumCircuit(2)
+    qc.cx(1, 0)
+    env.reset(qc)
+    env.layout = TranspileLayout(
+        initial_layout=Layout({qubit: index for index, qubit in enumerate(qc.qubits)}),
+        input_qubit_mapping={qubit: index for index, qubit in enumerate(qc.qubits)},
+        final_layout=None,
+        _output_qubit_list=qc.qubits,
+        _input_qubit_count=qc.num_qubits,
+    )
+    env.valid_actions = env.determine_valid_actions_for_state()
+    action_index = next(index for index in env.actions_routing_indices if env.action_set[index].name == "GateDirection")
+
+    assert env.action_masks()[action_index]
+    assert env.is_circuit_routed(env.apply_action(action_index), target.build_coupling_map())
 
 
 def test_predictor_env_truncates_at_max_steps() -> None:

--- a/tests/compilation/test_predictor_rl.py
+++ b/tests/compilation/test_predictor_rl.py
@@ -149,32 +149,15 @@ def test_qcompile_with_false_input() -> None:
         rl_compile(qc, device=None, figure_of_merit="expected_fidelity")
 
 
-def test_unidirectional_device_warning_and_gate_direction() -> None:
-    """Test warning and gate-direction routing for a unidirectional device."""
+def test_warning_for_unidirectional_device() -> None:
+    """Test the warning for a unidirectional device."""
     target = Target()
     target.add_instruction(CXGate(), {(0, 1): InstructionProperties()})
     target.description = "uni-directional device"
 
     msg = "The connectivity of the device 'uni-directional device' is uni-directional and MQT Predictor might return a compiled circuit that assumes bi-directionality."
     with pytest.warns(UserWarning, match=re.escape(msg)):
-        predictor = Predictor(figure_of_merit="expected_fidelity", device=target)
-
-    env = predictor.env
-    qc = QuantumCircuit(2)
-    qc.cx(1, 0)
-    env.reset(qc)
-    env.layout = TranspileLayout(
-        initial_layout=Layout({qubit: index for index, qubit in enumerate(qc.qubits)}),
-        input_qubit_mapping={qubit: index for index, qubit in enumerate(qc.qubits)},
-        final_layout=None,
-        _output_qubit_list=qc.qubits,
-        _input_qubit_count=qc.num_qubits,
-    )
-    env.valid_actions = env.determine_valid_actions_for_state()
-    action_index = next(index for index in env.actions_routing_indices if env.action_set[index].name == "GateDirection")
-
-    assert env.action_masks()[action_index]
-    assert env.is_circuit_routed(env.apply_action(action_index), target.build_coupling_map())
+        Predictor(figure_of_merit="expected_fidelity", device=target)
 
 
 def test_predictor_env_truncates_at_max_steps() -> None:

--- a/tests/compilation/test_predictor_rl.py
+++ b/tests/compilation/test_predictor_rl.py
@@ -163,7 +163,7 @@ def test_warning_for_unidirectional_device() -> None:
 def test_predictor_env_truncates_at_max_steps() -> None:
     """Test that the environment truncates episodes that hit the step limit."""
     device = get_device("ibm_falcon_27")
-    env = predictorenv_module.PredictorEnv(device=device, max_steps=1)
+    env = predictorenv_module.PredictorEnv(device=device, max_steps=1, intermediate_reward=False)
     qc = QuantumCircuit(1)
     qc.h(0)
     env.reset(qc)


### PR DESCRIPTION
🤖 *AI text below* 🤖

## Description

Enables intermediate rewards in `PredictorEnv` by default. For `expected_fidelity` and `estimated_success_probability`, comparable non-terminal steps use changes in the exact or approximate figure of merit. Transitions between incomparable reward regimes remain neutral, and optimization actions with no measurable change receive a configurable penalty.

Set `intermediate_reward=False` to retain terminal-only rewards. `reward_scale` and `no_effect_penalty` configure the shaping behavior on `PredictorEnv`.

This stacked PR depends on #781. Validated with `uvx nox -s lint`.

Fixes #670

## Checklist

- [x] The pull request only contains commits that are focused and relevant to this change.
- [ ] I have added appropriate tests that cover the new/changed functionality.
- [x] I have updated the documentation to reflect these changes.
- [x] I have added entries to the changelog for any noteworthy additions, changes, fixes, or removals.
- [x] I have added migration instructions to the upgrade guide (if needed).
- [x] The changes follow the project's style guidelines and introduce no new warnings.
- [ ] The changes are fully tested and pass the CI checks.
- [ ] I have reviewed my own code changes.

**If PR contains AI-assisted content:**

- [x] Any agent that created, edited, or submitted GitHub content was explicitly authorized for that scope, as required by our [AI Usage Guidelines](https://github.com/munich-quantum-toolkit/predictor/blob/main/docs/ai_usage.md).
- [x] Every agent-authored or agent-edited public text body begins with the visible disclosure `🤖 *AI text below* 🤖` (titles are exempt).
- [x] I have disclosed AI assistance in the PR description.
- [ ] I confirm that I have personally reviewed and understood all AI-generated content, and accept full responsibility for it.
