### PR TITLE
👷 Reduce CI load for draft pull requests

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -12,13 +12,13 @@ permissions: {}
 jobs:
   build-sdist:
     name: 🐍 Packaging
-    uses: munich-quantum-toolkit/workflows/.github/workflows/reusable-python-packaging-sdist.yml@f33c11c5cf68957b3074fff11ae43cfce2aaf593 # v2.2.3
+    uses: munich-quantum-toolkit/workflows/.github/workflows/reusable-python-packaging-sdist.yml@063c90c8e7e094bfffb73f8436eb55341c1e820f # v2.3.0
     permissions:
       contents: read
 
   build-wheel:
     name: 🐍 Packaging
-    uses: munich-quantum-toolkit/workflows/.github/workflows/reusable-python-packaging-wheel-build.yml@f33c11c5cf68957b3074fff11ae43cfce2aaf593 # v2.2.3
+    uses: munich-quantum-toolkit/workflows/.github/workflows/reusable-python-packaging-wheel-build.yml@063c90c8e7e094bfffb73f8436eb55341c1e820f # v2.3.0
     permissions:
       contents: read
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ on:
     branches:
       - main
   pull_request:
-    types: [opened, reopened, synchronize, ready_for_review, converted_to_draft]
+    types: [opened, reopened, synchronize, ready_for_review]
   merge_group:
   workflow_dispatch:
 
@@ -17,7 +17,7 @@ permissions: {}
 jobs:
   change-detection:
     name: 🔍 Change
-    uses: munich-quantum-toolkit/workflows/.github/workflows/reusable-change-detection.yml@f33c11c5cf68957b3074fff11ae43cfce2aaf593 # v2.2.3
+    uses: munich-quantum-toolkit/workflows/.github/workflows/reusable-change-detection.yml@063c90c8e7e094bfffb73f8436eb55341c1e820f # v2.3.0
     permissions:
       contents: read
 
@@ -28,10 +28,18 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        runs-on: [ubuntu-24.04, macos-26, windows-2025]
-    uses: munich-quantum-toolkit/workflows/.github/workflows/reusable-python-tests.yml@f33c11c5cf68957b3074fff11ae43cfce2aaf593 # v2.2.3
+        include:
+          - runs-on: ubuntu-24.04
+            sessions: '["minimums", "tests", "model-training"]'
+          - runs-on: macos-26
+            sessions: '["minimums", "tests"]'
+          - runs-on: windows-2025
+            sessions: '["minimums", "tests"]'
+    uses: munich-quantum-toolkit/workflows/.github/workflows/reusable-python-tests.yml@063c90c8e7e094bfffb73f8436eb55341c1e820f # v2.3.0
     with:
       runs-on: ${{ matrix.runs-on }}
+      sessions: ${{ matrix.sessions }}
+      draft-sessions: '["tests-3.14"]'
     permissions:
       contents: read
 
@@ -39,7 +47,7 @@ jobs:
     name: 🐍 Coverage
     needs: [change-detection, python-tests]
     if: fromJSON(needs.change-detection.outputs.run-python-tests)
-    uses: munich-quantum-toolkit/workflows/.github/workflows/reusable-python-coverage.yml@f33c11c5cf68957b3074fff11ae43cfce2aaf593 # v2.2.3
+    uses: munich-quantum-toolkit/workflows/.github/workflows/reusable-python-coverage.yml@063c90c8e7e094bfffb73f8436eb55341c1e820f # v2.3.0
     permissions:
       contents: read
       id-token: write
@@ -48,7 +56,7 @@ jobs:
     name: 🐍 Lint
     needs: change-detection
     if: fromJSON(needs.change-detection.outputs.run-python-linter)
-    uses: munich-quantum-toolkit/workflows/.github/workflows/reusable-python-linter.yml@f33c11c5cf68957b3074fff11ae43cfce2aaf593 # v2.2.3
+    uses: munich-quantum-toolkit/workflows/.github/workflows/reusable-python-linter.yml@063c90c8e7e094bfffb73f8436eb55341c1e820f # v2.3.0
     with:
       enable-ty: true
       enable-mypy: false
@@ -59,7 +67,7 @@ jobs:
     name: 🚀 CD
     needs: change-detection
     if: fromJSON(needs.change-detection.outputs.run-cd)
-    uses: munich-quantum-toolkit/workflows/.github/workflows/reusable-python-packaging-sdist.yml@f33c11c5cf68957b3074fff11ae43cfce2aaf593 # v2.2.3
+    uses: munich-quantum-toolkit/workflows/.github/workflows/reusable-python-packaging-sdist.yml@063c90c8e7e094bfffb73f8436eb55341c1e820f # v2.3.0
     permissions:
       contents: read
 
@@ -67,7 +75,7 @@ jobs:
     name: 🚀 CD
     needs: change-detection
     if: fromJSON(needs.change-detection.outputs.run-cd)
-    uses: munich-quantum-toolkit/workflows/.github/workflows/reusable-python-packaging-wheel-build.yml@f33c11c5cf68957b3074fff11ae43cfce2aaf593 # v2.2.3
+    uses: munich-quantum-toolkit/workflows/.github/workflows/reusable-python-packaging-wheel-build.yml@063c90c8e7e094bfffb73f8436eb55341c1e820f # v2.3.0
     permissions:
       contents: read
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,7 @@ on:
     branches:
       - main
   pull_request:
+    types: [opened, reopened, synchronize, ready_for_review, converted_to_draft]
   merge_group:
   workflow_dispatch:
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -17,9 +17,11 @@ from __future__ import annotations
 
 import argparse
 import contextlib
+import json
 import os
 import shutil
 import tempfile
+from pathlib import Path
 from typing import TYPE_CHECKING
 
 import nox
@@ -35,6 +37,28 @@ nox.options.default_venv_backend = "uv"
 # TODO(denialhaag): Add 3.14 when all dependencies support it
 #   https://github.com/munich-quantum-toolkit/predictor/issues/420
 PYTHON_ALL_VERSIONS = ["3.10", "3.11", "3.12", "3.13"]
+PYTHON_LATEST_VERSION = PYTHON_ALL_VERSIONS[-1]
+
+
+def _is_draft_pull_request() -> bool:
+    """Determine whether GitHub Actions is running for a draft pull request."""
+    event_path = os.environ.get("GITHUB_EVENT_PATH")
+    if os.environ.get("GITHUB_EVENT_NAME") != "pull_request" or event_path is None:
+        return False
+
+    with Path(event_path).open(encoding="utf-8") as event_file:
+        event = json.load(event_file)
+    return bool(event.get("pull_request", {}).get("draft", False))
+
+
+IS_DRAFT_PULL_REQUEST = _is_draft_pull_request()
+PYTHON_TEST_VERSIONS = PYTHON_ALL_VERSIONS[-1:] if IS_DRAFT_PULL_REQUEST else PYTHON_ALL_VERSIONS
+
+RL_MODEL_TESTS = (
+    "tests/compilation/test_predictor_rl.py::test_qcompile_with_newly_trained_models",
+    "tests/compilation/test_predictor_rl.py::test_qcompile_generates_trace_file",
+    "tests/hellinger_distance/test_estimated_hellinger_distance.py::test_train_and_qcompile_with_hellinger_model",
+)
 
 if os.environ.get("CI", None):
     nox.options.error_on_missing_interpreters = True
@@ -66,8 +90,17 @@ def _run_tests(
     install_args: Sequence[str] = (),
     extra_command: Sequence[str] = (),
     pytest_run_args: Sequence[str] = (),
+    run_rl_training: bool = False,
 ) -> None:
     env = {"UV_PROJECT_ENVIRONMENT": session.virtualenv.location}
+
+    if os.environ.get("GITHUB_ACTIONS") == "true" and not (
+        run_rl_training
+        and not IS_DRAFT_PULL_REQUEST
+        and os.environ.get("RUNNER_OS") == "Linux"
+        and session.python == PYTHON_LATEST_VERSION
+    ):
+        pytest_run_args = (*pytest_run_args, *(f"--deselect={test}" for test in RL_MODEL_TESTS))
 
     if extra_command:
         session.run(*extra_command, env=env)
@@ -86,13 +119,13 @@ def _run_tests(
     )
 
 
-@nox.session(python=PYTHON_ALL_VERSIONS, reuse_venv=True, default=True)
+@nox.session(python=PYTHON_TEST_VERSIONS, reuse_venv=True, default=True)
 def tests(session: nox.Session) -> None:
     """Run the test suite."""
-    _run_tests(session)
+    _run_tests(session, run_rl_training=True)
 
 
-@nox.session(python=PYTHON_ALL_VERSIONS, reuse_venv=True, venv_backend="uv", default=True)
+@nox.session(python=PYTHON_TEST_VERSIONS, reuse_venv=True, venv_backend="uv", default=True)
 def minimums(session: nox.Session) -> None:
     """Test the minimum versions of dependencies."""
     with preserve_lockfile():

--- a/noxfile.py
+++ b/noxfile.py
@@ -17,11 +17,9 @@ from __future__ import annotations
 
 import argparse
 import contextlib
-import json
 import os
 import shutil
 import tempfile
-from pathlib import Path
 from typing import TYPE_CHECKING
 
 import nox
@@ -35,27 +33,6 @@ nox.options.default_venv_backend = "uv"
 
 PYTHON_ALL_VERSIONS = ["3.11", "3.12", "3.13", "3.14"]
 PYTHON_LATEST_VERSION = PYTHON_ALL_VERSIONS[-1]
-
-
-def _is_draft_pull_request() -> bool:
-    """Determine whether GitHub Actions is running for a draft pull request."""
-    event_path = os.environ.get("GITHUB_EVENT_PATH")
-    if os.environ.get("GITHUB_EVENT_NAME") != "pull_request" or event_path is None:
-        return False
-
-    with Path(event_path).open(encoding="utf-8") as event_file:
-        event = json.load(event_file)
-    return bool(event.get("pull_request", {}).get("draft", False))
-
-
-IS_DRAFT_PULL_REQUEST = _is_draft_pull_request()
-PYTHON_TEST_VERSIONS = PYTHON_ALL_VERSIONS[-1:] if IS_DRAFT_PULL_REQUEST else PYTHON_ALL_VERSIONS
-
-RL_MODEL_TESTS = (
-    "tests/compilation/test_predictor_rl.py::test_qcompile_with_newly_trained_models",
-    "tests/compilation/test_predictor_rl.py::test_qcompile_generates_trace_file",
-    "tests/hellinger_distance/test_estimated_hellinger_distance.py::test_train_and_qcompile_with_hellinger_model",
-)
 
 if os.environ.get("CI", None):
     nox.options.error_on_missing_interpreters = True
@@ -87,17 +64,8 @@ def _run_tests(
     install_args: Sequence[str] = (),
     extra_command: Sequence[str] = (),
     pytest_run_args: Sequence[str] = (),
-    run_rl_training: bool = False,
 ) -> None:
     env = {"UV_PROJECT_ENVIRONMENT": session.virtualenv.location}
-
-    if os.environ.get("GITHUB_ACTIONS") == "true" and not (
-        run_rl_training
-        and not IS_DRAFT_PULL_REQUEST
-        and os.environ.get("RUNNER_OS") == "Linux"
-        and session.python == PYTHON_LATEST_VERSION
-    ):
-        pytest_run_args = (*pytest_run_args, *(f"--deselect={test}" for test in RL_MODEL_TESTS))
 
     if extra_command:
         session.run(*extra_command, env=env)
@@ -116,23 +84,29 @@ def _run_tests(
     )
 
 
-@nox.session(python=PYTHON_TEST_VERSIONS, reuse_venv=True, default=True)
+@nox.session(python=PYTHON_ALL_VERSIONS, reuse_venv=True, default=True)
 def tests(session: nox.Session) -> None:
     """Run the test suite."""
-    _run_tests(session, run_rl_training=True)
+    _run_tests(session, pytest_run_args=["-m", "not model_training"])
 
 
-@nox.session(python=PYTHON_TEST_VERSIONS, reuse_venv=True, venv_backend="uv", default=True)
+@nox.session(python=PYTHON_ALL_VERSIONS, reuse_venv=True, venv_backend="uv", default=True)
 def minimums(session: nox.Session) -> None:
     """Test the minimum versions of dependencies."""
     with preserve_lockfile():
         _run_tests(
             session,
             install_args=["--resolution=lowest-direct"],
-            pytest_run_args=["-Wdefault"],
+            pytest_run_args=["-Wdefault", "-m", "not model_training"],
         )
         env = {"UV_PROJECT_ENVIRONMENT": session.virtualenv.location}
         session.run("uv", "tree", "--frozen", env=env)
+
+
+@nox.session(name="model-training", python=PYTHON_LATEST_VERSION, reuse_venv=True)
+def model_training(session: nox.Session) -> None:
+    """Run tests that train models."""
+    _run_tests(session, pytest_run_args=["-m", "model_training"])
 
 
 @nox.session(reuse_venv=True)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -116,6 +116,9 @@ addopts = [
     "-ra",
     "--showlocals",
 ]
+markers = [
+    "model_training: tests that train prediction models",
+]
 log_level = "INFO"
 filterwarnings = [
     'error',

--- a/tests/compilation/test_predictor_rl.py
+++ b/tests/compilation/test_predictor_rl.py
@@ -65,6 +65,7 @@ def test_predictor_env_hellinger_error() -> None:
         Predictor(figure_of_merit="estimated_hellinger_distance", device=device)
 
 
+@pytest.mark.model_training
 def test_qcompile_with_newly_trained_models() -> None:
     """Test the qcompile function with a newly trained model.
 
@@ -218,6 +219,7 @@ def test_register_action(monkeypatch: pytest.MonkeyPatch) -> None:
         register_action(action)
 
 
+@pytest.mark.model_training
 def test_qcompile_generates_trace_file(tmp_path: Path) -> None:
     """Test that rl_compile correctly generates a trace JSON file when tracing is enabled."""
     figure_of_merit = "expected_fidelity"

--- a/tests/device_selection/test_predictor_ml.py
+++ b/tests/device_selection/test_predictor_ml.py
@@ -35,6 +35,7 @@ def path_compiled_circuits() -> Path:
     return Path("./test_compiled_circuits")
 
 
+@pytest.mark.model_training
 def test_setup_device_predictor_with_prediction(path_uncompiled_circuits: Path, path_compiled_circuits: Path) -> None:
     """Test the full training pipeline and prediction using a mock device."""
     if not path_uncompiled_circuits.exists():
@@ -90,6 +91,7 @@ def test_remove_files(path_uncompiled_circuits: Path, path_compiled_circuits: Pa
                 file.unlink()
 
 
+@pytest.mark.model_training
 def test_predict_device_for_figure_of_merit_no_suitable_device() -> None:
     """Test the prediction of the device for a given figure of merit with a wrong device name."""
     num_qubits = 130

--- a/tests/hellinger_distance/test_estimated_hellinger_distance.py
+++ b/tests/hellinger_distance/test_estimated_hellinger_distance.py
@@ -182,6 +182,7 @@ def test_train_random_forest_regressor_and_predict(device: Target) -> None:
     assert np.isclose(trained_model.predict([feature_vector]), distance_label)
 
 
+@pytest.mark.model_training
 def test_train_and_qcompile_with_hellinger_model(source_path: Path, target_path: Path, device: Target) -> None:
     """Test the entire predictor toolchain with the Hellinger distance model that was trained in the previous test."""
     figure_of_merit = "estimated_hellinger_distance"

--- a/tests/hellinger_distance/test_estimated_hellinger_distance.py
+++ b/tests/hellinger_distance/test_estimated_hellinger_distance.py
@@ -152,6 +152,7 @@ def test_hellinger_distance_error() -> None:
         hellinger_distance(p=invalid, q=valid)
 
 
+@pytest.mark.model_training
 def test_train_random_forest_regressor_and_predict(device: Target) -> None:
     """Test the training of the random forest regressor. The trained model is saved and used in the following tests."""
     # Setup the training environment


### PR DESCRIPTION
## Description

🤖 *AI text below* 🤖

Reduce CI load while preserving full coverage once a pull request is ready for review:

- Draft pull requests run `tests` only on the latest supported Python version (3.14) across Ubuntu, macOS, and Windows.
- Ready pull requests retain the full Python 3.11–3.14 matrix.
- Tests that train models run once per workflow in the dedicated Linux/Python 3.14 `model-training` session and are skipped while a pull request is a draft.
- Marking a draft pull request as ready for review triggers the full CI run.

Push, merge-queue, and manual runs retain the full matrix and one Linux/Python 3.14 model-training run.

## AI notice

This PR and its contents were created with the assistance of GPT-5.6 Sol via Codex.

## Checklist

- [x] The pull request only contains commits that are focused and relevant to this change.
- [x] I have added appropriate tests that cover the new/changed functionality.
- [x] I have updated the documentation to reflect these changes. (Not applicable for CI-only behavior.)
- [x] I have added entries to the changelog for any noteworthy additions, changes, fixes, or removals. (Not applicable for CI-only behavior.)
- [x] I have added migration instructions to the upgrade guide (if needed). (Not needed.)
- [x] The changes follow the project's style guidelines and introduce no new warnings.
- [x] The changes are fully tested and pass the CI checks.
- [x] I have reviewed my own code changes.

**If PR contains AI-assisted content:**

- [x] Any agent that created, edited, or submitted GitHub content was explicitly authorized for that scope, as required by our [AI Usage Guidelines](https://github.com/munich-quantum-toolkit/predictor/blob/main/docs/ai_usage.md).
- [x] Every agent-authored or agent-edited public text body begins with the visible disclosure `🤖 *AI text below* 🤖` (titles are exempt).
- [x] I have disclosed AI assistance in the PR description.
- [x] I confirm that I have personally reviewed and understood all AI-generated content, and accept full responsibility for it.
