### PR TITLE
♻️ Split RL actions package into `base` and `registry` modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ releases may include breaking changes.
 
 ### Changed
 
+- ♻️ Split RL actions package into `base` and `registry` modules ([#769])
+  ([**@denialhaag**])
 - ✨ Replace composite BQSKit compilation actions with atomic passes ([#731])
   ([**@flowerthrower**])
 
@@ -77,6 +79,7 @@ for previous changelogs._
 
 <!-- PR links -->
 
+[#769]: https://github.com/munich-quantum-toolkit/predictor/pull/769
 [#697]: https://github.com/munich-quantum-toolkit/predictor/pull/697
 [#731]: https://github.com/munich-quantum-toolkit/predictor/pull/731
 [#714]: https://github.com/munich-quantum-toolkit/predictor/pull/714

--- a/src/mqt/predictor/rl/actions/__init__.py
+++ b/src/mqt/predictor/rl/actions/__init__.py
@@ -8,138 +8,17 @@
 
 """Actions (i.e. compiler passes) available in the reinforcement learning environment."""
 
-# ruff: file-ignore[non-empty-init-module]
-
 from __future__ import annotations
 
-from collections import defaultdict
-from dataclasses import dataclass
-from enum import Enum
-from typing import TYPE_CHECKING, Any
-
-if TYPE_CHECKING:
-    from collections.abc import Callable
-
-    from qiskit.passmanager import PropertySet
-
-
-class CompilationOrigin(str, Enum):
-    """Enumeration of the origin of the compilation action."""
-
-    QISKIT = "qiskit"
-    TKET = "tket"
-    BQSKIT = "bqskit"
-
-
-class PassType(str, Enum):
-    """Enumeration of the type of compilation pass."""
-
-    OPT = "optimization"
-    SYNTHESIS = "synthesis"
-    MAPPING = "mapping"
-    LAYOUT = "layout"
-    ROUTING = "routing"
-    FINAL_OPT = "final_optimization"
-    TERMINATE = "terminate"
-
-
-@dataclass
-class Action:
-    """Base class for all actions in the reinforcement learning environment.
-
-    Attributes:
-        name: Unique action name.
-        origin: SDK origin of the action; ``None`` for terminate.
-        pass_type: Category of pass represented by this action.
-        transpile_pass: Pass object(s) executed for this action.
-        preserves_layout: Whether action preserves existing layout.
-        preserves_routing: Whether action preserves existing routing.
-        preserves_synthesis: Whether action preserves synthesis state.
-    """
-
-    name: str
-    origin: CompilationOrigin | None
-    pass_type: PassType
-    transpile_pass: Any
-    preserves_layout: bool = False
-    preserves_routing: bool = False
-    preserves_synthesis: bool = False
-
-
-@dataclass
-class DeviceIndependentAction(Action):
-    """Action that represents a static compilation pass that can be applied directly."""
-
-
-@dataclass
-class DeferredDeviceAction(Action):
-    """Action that defers construction of a device-specific pass.
-
-    Attributes:
-        do_while: Optional do-while predicate for pass-manager execution.
-    """
-
-    transpile_pass: Any
-    do_while: Callable[[PropertySet], bool] | None = None
-
-
-_ACTIONS: dict[str, Action] = {}
-
-
-def register_action(action: Action) -> Action:
-    """Registers a new Action in the global _ACTIONS registry.
-
-    Args:
-        action: Action to register.
-
-    Returns:
-        The registered Action.
-
-    Raises:
-        ValueError: If an action with the same name is already registered.
-    """
-    if action.name in _ACTIONS:
-        msg = f"Action with name {action.name} already registered."
-        raise ValueError(msg)
-    _ACTIONS[action.name] = action
-    return action
-
-
-def get_actions_by_pass_type() -> dict[PassType, list[Action]]:
-    """Groups registered Actions from the global _ACTIONS registry by PassType.
-
-    Returns:
-        A dictionary mapping each PassType to the list of registered Actions of that type.
-    """
-    result: dict[PassType, list[Action]] = defaultdict(list)
-    for action in _ACTIONS.values():
-        result[action.pass_type].append(action)
-    return result
-
-
 from mqt.predictor.rl.actions import bqskit_actions, qiskit_actions, tket_actions
-
-for _action in (
-    *qiskit_actions.qiskit_layout_actions(),
-    qiskit_actions.qiskit_mapping_action(),
-    qiskit_actions.qiskit_synthesis_action(),
-    qiskit_actions.qiskit_o3_action(),
-    *qiskit_actions.qiskit_optimization_actions(),
-    qiskit_actions.qiskit_final_optimization_action(),
-    tket_actions.tket_routing_action(),
-    *tket_actions.tket_optimization_actions(),
-    *bqskit_actions.bqskit_layout_actions(),
-    *bqskit_actions.bqskit_routing_actions(),
-    *bqskit_actions.bqskit_mapping_actions(),
-    *bqskit_actions.bqskit_synthesis_actions(),
-    DeviceIndependentAction(
-        "terminate",
-        None,
-        PassType.TERMINATE,
-        transpile_pass=[],
-    ),
-):
-    register_action(_action)
+from mqt.predictor.rl.actions.base import (
+    Action,
+    CompilationOrigin,
+    DeferredDeviceAction,
+    DeviceIndependentAction,
+    PassType,
+)
+from mqt.predictor.rl.actions.registry import get_actions_by_pass_type, register_action
 
 __all__ = [
     "Action",

--- a/src/mqt/predictor/rl/actions/base.py
+++ b/src/mqt/predictor/rl/actions/base.py
@@ -1,0 +1,80 @@
+# Copyright (c) 2023 - 2026 Chair for Design Automation, TUM
+# Copyright (c) 2025 - 2026 Munich Quantum Software Company GmbH
+# All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+#
+# Licensed under the MIT License
+
+"""Action types describing the compiler passes available in the reinforcement learning environment."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    from qiskit.passmanager import PropertySet
+
+
+class CompilationOrigin(str, Enum):
+    """Enumeration of the origin of the compilation action."""
+
+    QISKIT = "qiskit"
+    TKET = "tket"
+    BQSKIT = "bqskit"
+
+
+class PassType(str, Enum):
+    """Enumeration of the type of compilation pass."""
+
+    OPT = "optimization"
+    SYNTHESIS = "synthesis"
+    MAPPING = "mapping"
+    LAYOUT = "layout"
+    ROUTING = "routing"
+    FINAL_OPT = "final_optimization"
+    TERMINATE = "terminate"
+
+
+@dataclass
+class Action:
+    """Base class for all actions in the reinforcement learning environment.
+
+    Attributes:
+        name: Unique action name.
+        origin: SDK origin of the action; ``None`` for terminate.
+        pass_type: Category of pass represented by this action.
+        transpile_pass: Pass object(s) executed for this action.
+        preserves_layout: Whether action preserves existing layout.
+        preserves_routing: Whether action preserves existing routing.
+        preserves_synthesis: Whether action preserves synthesis state.
+    """
+
+    name: str
+    origin: CompilationOrigin | None
+    pass_type: PassType
+    transpile_pass: Any
+    preserves_layout: bool = False
+    preserves_routing: bool = False
+    preserves_synthesis: bool = False
+
+
+@dataclass
+class DeviceIndependentAction(Action):
+    """Action that represents a static compilation pass that can be applied directly."""
+
+
+@dataclass
+class DeferredDeviceAction(Action):
+    """Action that defers construction of a device-specific pass.
+
+    Attributes:
+        do_while: Optional do-while predicate for pass-manager execution.
+    """
+
+    transpile_pass: Any
+    do_while: Callable[[PropertySet], bool] | None = None

--- a/src/mqt/predictor/rl/actions/bqskit_actions.py
+++ b/src/mqt/predictor/rl/actions/bqskit_actions.py
@@ -54,7 +54,7 @@ from qiskit.circuit import Instruction, QuantumRegister
 from qiskit.circuit.library import RGate
 from qiskit.transpiler import Layout, TranspileLayout
 
-from mqt.predictor.rl.actions import CompilationOrigin, DeferredDeviceAction, PassType
+from mqt.predictor.rl.actions.base import CompilationOrigin, DeferredDeviceAction, PassType
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -68,7 +68,7 @@ if TYPE_CHECKING:
     from qiskit.circuit import Qubit as QiskitQubit
     from qiskit.transpiler import Target
 
-    from mqt.predictor.rl.actions import Action
+    from mqt.predictor.rl.actions.base import Action
 
     BQSKitMapping: TypeAlias = tuple[Circuit, tuple[int, ...], tuple[int, ...]]
 

--- a/src/mqt/predictor/rl/actions/qiskit_actions.py
+++ b/src/mqt/predictor/rl/actions/qiskit_actions.py
@@ -62,7 +62,7 @@ from qiskit.transpiler.passes import (
 from qiskit.transpiler.passes.layout.vf2_layout import VF2LayoutStopReason
 from qiskit.transpiler.preset_passmanagers import common
 
-from mqt.predictor.rl.actions import (
+from mqt.predictor.rl.actions.base import (
     CompilationOrigin,
     DeferredDeviceAction,
     DeviceIndependentAction,
@@ -77,9 +77,7 @@ if TYPE_CHECKING:
     from qiskit.passmanager.base_tasks import Task
     from qiskit.transpiler import Layout, Target
 
-    from mqt.predictor.rl.actions import (
-        Action,
-    )
+    from mqt.predictor.rl.actions.base import Action
 
 logger = logging.getLogger("mqt-predictor")
 

--- a/src/mqt/predictor/rl/actions/registry.py
+++ b/src/mqt/predictor/rl/actions/registry.py
@@ -1,0 +1,72 @@
+# Copyright (c) 2023 - 2026 Chair for Design Automation, TUM
+# Copyright (c) 2025 - 2026 Munich Quantum Software Company GmbH
+# All rights reserved.
+#
+# SPDX-License-Identifier: MIT
+#
+# Licensed under the MIT License
+
+"""Registry of the actions (i.e. compiler passes) available in the reinforcement learning environment."""
+
+from __future__ import annotations
+
+from collections import defaultdict
+
+from mqt.predictor.rl.actions import bqskit_actions, qiskit_actions, tket_actions
+from mqt.predictor.rl.actions.base import Action, DeviceIndependentAction, PassType
+
+_ACTIONS: dict[str, Action] = {}
+
+
+def register_action(action: Action) -> Action:
+    """Registers a new Action in the global _ACTIONS registry.
+
+    Args:
+        action: Action to register.
+
+    Returns:
+        The registered Action.
+
+    Raises:
+        ValueError: If an action with the same name is already registered.
+    """
+    if action.name in _ACTIONS:
+        msg = f"Action with name {action.name} already registered."
+        raise ValueError(msg)
+    _ACTIONS[action.name] = action
+    return action
+
+
+def get_actions_by_pass_type() -> dict[PassType, list[Action]]:
+    """Groups registered Actions from the global _ACTIONS registry by PassType.
+
+    Returns:
+        A dictionary mapping each PassType to the list of registered Actions of that type.
+    """
+    result: dict[PassType, list[Action]] = defaultdict(list)
+    for action in _ACTIONS.values():
+        result[action.pass_type].append(action)
+    return result
+
+
+for _action in (
+    *qiskit_actions.qiskit_layout_actions(),
+    qiskit_actions.qiskit_mapping_action(),
+    qiskit_actions.qiskit_synthesis_action(),
+    qiskit_actions.qiskit_o3_action(),
+    *qiskit_actions.qiskit_optimization_actions(),
+    qiskit_actions.qiskit_final_optimization_action(),
+    tket_actions.tket_routing_action(),
+    *tket_actions.tket_optimization_actions(),
+    *bqskit_actions.bqskit_layout_actions(),
+    *bqskit_actions.bqskit_routing_actions(),
+    *bqskit_actions.bqskit_mapping_actions(),
+    *bqskit_actions.bqskit_synthesis_actions(),
+    DeviceIndependentAction(
+        "terminate",
+        None,
+        PassType.TERMINATE,
+        transpile_pass=[],
+    ),
+):
+    register_action(_action)

--- a/src/mqt/predictor/rl/actions/tket_actions.py
+++ b/src/mqt/predictor/rl/actions/tket_actions.py
@@ -22,7 +22,7 @@ from pytket.passes import CliffordSimp, FullPeepholeOptimise, PeepholeOptimise2Q
 from pytket.placement import place_with_map
 from qiskit.transpiler import Layout
 
-from mqt.predictor.rl.actions import CompilationOrigin, DeferredDeviceAction, DeviceIndependentAction, PassType
+from mqt.predictor.rl.actions.base import CompilationOrigin, DeferredDeviceAction, DeviceIndependentAction, PassType
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -32,7 +32,7 @@ if TYPE_CHECKING:
     from qiskit.passmanager.base_tasks import Task
     from qiskit.transpiler import Target, TranspileLayout
 
-    from mqt.predictor.rl.actions import Action
+    from mqt.predictor.rl.actions.base import Action
 
 
 class PreProcessTKETRoutingAfterQiskitLayout:

--- a/tests/compilation/test_predictor_rl.py
+++ b/tests/compilation/test_predictor_rl.py
@@ -22,7 +22,6 @@ from qiskit.qasm2 import dump
 from qiskit.transpiler import InstructionProperties, Layout, Target, TranspileLayout
 from qiskit.transpiler.passes import GatesInBasis
 
-import mqt.predictor.rl.actions as actions_module
 from mqt.predictor.rl import Predictor, rl_compile
 from mqt.predictor.rl import predictorenv as predictorenv_module
 from mqt.predictor.rl.actions import (
@@ -33,6 +32,7 @@ from mqt.predictor.rl.actions import (
     qiskit_actions,
     register_action,
 )
+from mqt.predictor.rl.actions import registry as actions_registry_module
 from mqt.predictor.rl.helper import create_feature_dict, get_path_trained_model
 
 
@@ -205,7 +205,7 @@ def test_predictor_env_qiskit_routing_updates_final_layout(monkeypatch: pytest.M
 
 def test_register_action(monkeypatch: pytest.MonkeyPatch) -> None:
     """Test the register_action function."""
-    actions_registry = vars(actions_module)
+    actions_registry = vars(actions_registry_module)
     monkeypatch.setitem(actions_registry, "_ACTIONS", actions_registry["_ACTIONS"].copy())
     action = DeviceIndependentAction(
         name="test_action", pass_type=PassType.OPT, transpile_pass=[], origin=CompilationOrigin.QISKIT


### PR DESCRIPTION
## Description

🤖 *AI text below* 🤖

The `mqt.predictor.rl.actions` package kept the action types, the action registry, and the import-time registration of all actions in its `__init__.py`. Since the SDK-specific modules import those types from the package, the package in turn had to import its own submodules at the bottom of `__init__.py`, after the definitions they depend on.

This splits the package up. `base.py` holds the action types, `registry.py` holds `register_action`, `get_actions_by_pass_type`, and the registration of all actions, and `__init__.py` only re-exports. The SDK-specific modules now import from `base`, which makes the dependency graph acyclic and removes the import at the bottom of `__init__.py`.

The public API is unchanged. Only the test that monkeypatches the registry had to be adapted, because `_ACTIONS` now lives in `registry`.

This also makes the `# ruff: file-ignore[non-empty-init-module]` suppression in `__init__.py` obsolete.

## AI notice

This PR and its contents were created with the assistance of Opus 5 via Claude Code.

## Checklist

- [x] The pull request only contains commits that are focused and relevant to this change.
- [x] ~~I have added appropriate tests that cover the new/changed functionality.~~
- [x] ~~I have updated the documentation to reflect these changes.~~
- [x] I have added entries to the changelog for any noteworthy additions, changes, fixes, or removals.
- [x] ~~I have added migration instructions to the upgrade guide (if needed).~~
- [x] The changes follow the project's style guidelines and introduce no new warnings.
- [x] The changes are fully tested and pass the CI checks.
- [x] I have reviewed my own code changes.

**If PR contains AI-assisted content:**

- [x] Any agent that created, edited, or submitted GitHub content was explicitly authorized for that scope, as required by our [AI Usage Guidelines](https://github.com/munich-quantum-toolkit/predictor/blob/main/docs/ai_usage.md).
- [x] Every agent-authored or agent-edited public text body begins with the visible disclosure `🤖 *AI text below* 🤖` (titles are exempt).
- [x] I have disclosed AI assistance in the PR description.
- [x] I confirm that I have personally reviewed and understood all AI-generated content, and accept full responsibility for it.
