### PR TITLE
⚡ Use compact scalar RL observations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ releases may include breaking changes.
 
 ### Added
 
+- ✨ Add Qiskit's stochastic `SabreSwap` pass to the RL routing actions ([#759])
+  ([**@flowerthrower**])
 - ✨ Extend the RL observation with normalized OpenQASM gate and measurement
   frequencies ([#758]) ([**@flowerthrower**])
 - 👷 Enable testing on Python 3.14 ([#488]) ([**@denialhaag**])
@@ -91,6 +93,7 @@ for previous changelogs._
 
 [#773]: https://github.com/munich-quantum-toolkit/predictor/pull/771
 [#769]: https://github.com/munich-quantum-toolkit/predictor/pull/769
+[#759]: https://github.com/munich-quantum-toolkit/predictor/pull/759
 [#758]: https://github.com/munich-quantum-toolkit/predictor/pull/758
 [#755]: https://github.com/munich-quantum-toolkit/predictor/pull/755
 [#731]: https://github.com/munich-quantum-toolkit/predictor/pull/731

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ releases may include breaking changes.
 
 ### Added
 
+- ✨ Extend the RL observation with normalized OpenQASM gate and measurement
+  frequencies ([#758]) ([**@flowerthrower**])
 - 👷 Enable testing on Python 3.14 ([#488]) ([**@denialhaag**])
 - ✨ Add selectable `v2` and `v3` RL MDP strategies, make `v3` the default, and
   use the selected strategy in compilation traces and model artifact names
@@ -89,6 +91,7 @@ for previous changelogs._
 
 [#773]: https://github.com/munich-quantum-toolkit/predictor/pull/771
 [#769]: https://github.com/munich-quantum-toolkit/predictor/pull/769
+[#758]: https://github.com/munich-quantum-toolkit/predictor/pull/758
 [#755]: https://github.com/munich-quantum-toolkit/predictor/pull/755
 [#731]: https://github.com/munich-quantum-toolkit/predictor/pull/731
 [#714]: https://github.com/munich-quantum-toolkit/predictor/pull/714

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ releases may include breaking changes.
 
 ### Changed
 
+- ⚡ Replace the one-hot `num_qubits` and `depth` RL observations with
+  normalized scalar values ([#770]) ([**@flowerthrower**])
 - ✨ Enable configurable intermediate rewards for RL training by default
   ([#760]) ([**@flowerthrower**])
 - 🔥 Drop support for Python 3.10 ([#773]) ([**@denialhaag**])
@@ -94,6 +96,7 @@ for previous changelogs._
 <!-- PR links -->
 
 [#773]: https://github.com/munich-quantum-toolkit/predictor/pull/771
+[#770]: https://github.com/munich-quantum-toolkit/predictor/pull/770
 [#769]: https://github.com/munich-quantum-toolkit/predictor/pull/769
 [#760]: https://github.com/munich-quantum-toolkit/predictor/pull/760
 [#759]: https://github.com/munich-quantum-toolkit/predictor/pull/759

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ releases may include breaking changes.
 
 ### Changed
 
+- ✨ Enable configurable intermediate rewards for RL training by default
+  ([#760]) ([**@flowerthrower**])
 - 🔥 Drop support for Python 3.10 ([#773]) ([**@denialhaag**])
 - ♻️ Split RL actions package into `base` and `registry` modules ([#769])
   ([**@denialhaag**])
@@ -93,6 +95,7 @@ for previous changelogs._
 
 [#773]: https://github.com/munich-quantum-toolkit/predictor/pull/771
 [#769]: https://github.com/munich-quantum-toolkit/predictor/pull/769
+[#760]: https://github.com/munich-quantum-toolkit/predictor/pull/760
 [#759]: https://github.com/munich-quantum-toolkit/predictor/pull/759
 [#758]: https://github.com/munich-quantum-toolkit/predictor/pull/758
 [#755]: https://github.com/munich-quantum-toolkit/predictor/pull/755

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -6,6 +6,13 @@ of changes including minor and patch releases, please refer to the
 
 ## [Unreleased]
 
+### Gate-frequency RL observations
+
+The RL observation now includes normalized frequencies for supported OpenQASM
+gates and measurements. This changes the observation space. Existing RL models
+must be retrained, and code that consumes `PredictorEnv` observations directly
+must accept the additional keys.
+
 ### End of support for Python 3.10
 
 Starting with this release, MQT Predictor no longer supports Python 3.10. As a

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -6,6 +6,15 @@ of changes including minor and patch releases, please refer to the
 
 ## [Unreleased]
 
+### Intermediate RL rewards
+
+`PredictorEnv` now enables intermediate rewards by default. For
+`expected_fidelity` and `estimated_success_probability`, comparable non-terminal
+steps are rewarded from changes in the exact or approximate figure of merit.
+Optimization actions with no measurable change receive `-0.001`. Set
+`intermediate_reward=False` to retain the previous terminal-only reward
+behavior; use `reward_scale` and `no_effect_penalty` to tune reward shaping.
+
 ### Qiskit SABRE routing action
 
 The RL action space now includes Qiskit's stochastic `SabreSwap` routing pass.

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -6,6 +6,13 @@ of changes including minor and patch releases, please refer to the
 
 ## [Unreleased]
 
+### Qiskit SABRE routing action
+
+The RL action space now includes Qiskit's stochastic `SabreSwap` routing pass.
+Existing RL models must be retrained because the action-space size and the
+indices of later actions have changed. Code that persists or selects actions by
+numeric index must be updated.
+
 ### Gate-frequency RL observations
 
 The RL observation now includes normalized frequencies for supported OpenQASM

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -6,6 +6,14 @@ of changes including minor and patch releases, please refer to the
 
 ## [Unreleased]
 
+### Compact RL observations
+
+The `num_qubits` and `depth` observation entries are now one-element `float32`
+arrays in `[0, 1]` instead of discrete integers. The qubit count is linearly
+scaled and capped at 127; the depth is `log1p`-scaled and capped at 999,999.
+Code that consumes `PredictorEnv` observations directly must handle the new
+array values, and existing RL models must be retrained.
+
 ### Intermediate RL rewards
 
 `PredictorEnv` now enables intermediate rewards by default. For

--- a/src/mqt/predictor/rl/actions/qiskit_actions.py
+++ b/src/mqt/predictor/rl/actions/qiskit_actions.py
@@ -54,6 +54,7 @@ from qiskit.transpiler.passes import (
     OptimizeCliffords,
     RemoveDiagonalGatesBeforeMeasure,
     SabreLayout,
+    SabreSwap,
     Size,
     UnitarySynthesis,
     VF2Layout,
@@ -249,6 +250,20 @@ def qiskit_layout_actions() -> list[Action]:
                 ],
             ),
         ),
+    ]
+
+
+def qiskit_routing_actions() -> list[Action]:
+    """Return the Qiskit routing actions."""
+    return [
+        DeferredDeviceAction(
+            "SabreSwap",
+            CompilationOrigin.QISKIT,
+            PassType.ROUTING,
+            transpile_pass=lambda device: cast(
+                "list[Task]", [SabreSwap(coupling_map=CouplingMap(device.build_coupling_map()), heuristic="decay")]
+            ),
+        )
     ]
 
 

--- a/src/mqt/predictor/rl/actions/registry.py
+++ b/src/mqt/predictor/rl/actions/registry.py
@@ -51,6 +51,7 @@ def get_actions_by_pass_type() -> dict[PassType, list[Action]]:
 
 for _action in (
     *qiskit_actions.qiskit_layout_actions(),
+    *qiskit_actions.qiskit_routing_actions(),
     qiskit_actions.qiskit_mapping_action(),
     qiskit_actions.qiskit_synthesis_action(),
     qiskit_actions.qiskit_o3_action(),

--- a/src/mqt/predictor/rl/helper.py
+++ b/src/mqt/predictor/rl/helper.py
@@ -17,7 +17,7 @@ from typing import TYPE_CHECKING
 import numpy as np
 from qiskit import QuantumCircuit
 
-from mqt.predictor.utils import calc_supermarq_features
+from mqt.predictor.utils import calc_supermarq_features, get_openqasm_gates_for_rl
 
 if TYPE_CHECKING:
     from numpy.random import Generator
@@ -70,22 +70,32 @@ def get_state_sample(max_qubits: int, path_training_circuits: Path, rng: Generat
     return qc, str(file_list[random_index])
 
 
+def dict_to_featurevector(gate_dict: dict[str, int]) -> dict[str, float]:
+    """Return normalized OpenQASM gate frequencies for an RL observation."""
+    feature_vector = dict.fromkeys(get_openqasm_gates_for_rl(), 0.0)
+    total = sum(value for gate, value in gate_dict.items() if gate != "barrier")
+    for gate, value in gate_dict.items():
+        if gate in feature_vector:
+            feature_vector[gate] = value / total if total else 0.0
+    return feature_vector
+
+
 def create_feature_dict(qc: QuantumCircuit) -> dict[str, int | NDArray[np.float32]]:
-    """Creates a feature dictionary for a given quantum circuit.
-
-    Arguments:
-        qc: The quantum circuit for which the feature dictionary is created.
-
-    Returns:
-        The feature dictionary for the given quantum circuit.
-    """
+    """Create a normalized feature dictionary for a quantum circuit."""
+    operation_counts = dict(qc.count_ops())
+    total_operations = sum(value for gate, value in operation_counts.items() if gate != "barrier")
+    gate_features = dict_to_featurevector(operation_counts)
     feature_dict: dict[str, int | NDArray[np.float32]] = {
+        **{gate: np.array([value], dtype=np.float32) for gate, value in gate_features.items()},
+        "measure": np.array(
+            [operation_counts.get("measure", 0) / total_operations if total_operations else 0.0],
+            dtype=np.float32,
+        ),
         "num_qubits": qc.num_qubits,
         "depth": qc.depth(),
     }
 
     supermarq_features = calc_supermarq_features(qc)
-    # for all dict values, put them in a list each
     feature_dict["program_communication"] = np.array([supermarq_features.program_communication], dtype=np.float32)
     feature_dict["critical_depth"] = np.array([supermarq_features.critical_depth], dtype=np.float32)
     feature_dict["entanglement_ratio"] = np.array([supermarq_features.entanglement_ratio], dtype=np.float32)

--- a/src/mqt/predictor/rl/helper.py
+++ b/src/mqt/predictor/rl/helper.py
@@ -11,6 +11,7 @@
 from __future__ import annotations
 
 import logging
+from math import log1p
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -27,6 +28,9 @@ import zipfile
 from importlib import resources
 
 logger = logging.getLogger("mqt-predictor")
+
+MAX_NUM_QUBITS = 127
+MAX_CIRCUIT_DEPTH = 999_999
 
 
 def get_state_sample(max_qubits: int, path_training_circuits: Path, rng: Generator) -> tuple[QuantumCircuit, str]:
@@ -80,19 +84,21 @@ def dict_to_featurevector(gate_dict: dict[str, int]) -> dict[str, float]:
     return feature_vector
 
 
-def create_feature_dict(qc: QuantumCircuit) -> dict[str, int | NDArray[np.float32]]:
+def create_feature_dict(qc: QuantumCircuit) -> dict[str, NDArray[np.float32]]:
     """Create a normalized feature dictionary for a quantum circuit."""
     operation_counts = dict(qc.count_ops())
     total_operations = sum(value for gate, value in operation_counts.items() if gate != "barrier")
     gate_features = dict_to_featurevector(operation_counts)
-    feature_dict: dict[str, int | NDArray[np.float32]] = {
+    normalized_num_qubits = min(qc.num_qubits, MAX_NUM_QUBITS) / MAX_NUM_QUBITS
+    normalized_depth = log1p(min(qc.depth(), MAX_CIRCUIT_DEPTH)) / log1p(MAX_CIRCUIT_DEPTH)
+    feature_dict = {
         **{gate: np.array([value], dtype=np.float32) for gate, value in gate_features.items()},
         "measure": np.array(
             [operation_counts.get("measure", 0) / total_operations if total_operations else 0.0],
             dtype=np.float32,
         ),
-        "num_qubits": qc.num_qubits,
-        "depth": qc.depth(),
+        "num_qubits": np.array([normalized_num_qubits], dtype=np.float32),
+        "depth": np.array([normalized_depth], dtype=np.float32),
     }
 
     supermarq_features = calc_supermarq_features(qc)

--- a/src/mqt/predictor/rl/predictorenv.py
+++ b/src/mqt/predictor/rl/predictorenv.py
@@ -175,9 +175,7 @@ class PredictorEnv(Env):
         self.has_parameterized_gates = False
         self.rng = np.random.default_rng(10)
 
-        gate_spaces = {
-            gate: Box(low=0, high=1, shape=(1,), dtype=np.float32) for gate in get_openqasm_gates_for_rl()
-        }
+        gate_spaces = {gate: Box(low=0, high=1, shape=(1,), dtype=np.float32) for gate in get_openqasm_gates_for_rl()}
         spaces: dict[str, Space] = {
             "num_qubits": Discrete(128),
             "depth": Discrete(1000000),

--- a/src/mqt/predictor/rl/predictorenv.py
+++ b/src/mqt/predictor/rl/predictorenv.py
@@ -191,8 +191,8 @@ class PredictorEnv(Env):
 
         gate_spaces = {gate: Box(low=0, high=1, shape=(1,), dtype=np.float32) for gate in get_openqasm_gates_for_rl()}
         spaces: dict[str, Space] = {
-            "num_qubits": Discrete(128),
-            "depth": Discrete(1000000),
+            "num_qubits": Box(low=0, high=1, shape=(1,), dtype=np.float32),
+            "depth": Box(low=0, high=1, shape=(1,), dtype=np.float32),
             "measure": Box(low=0, high=1, shape=(1,), dtype=np.float32),
             **gate_spaces,
             "program_communication": Box(low=0, high=1, shape=(1,), dtype=np.float32),

--- a/src/mqt/predictor/rl/predictorenv.py
+++ b/src/mqt/predictor/rl/predictorenv.py
@@ -11,6 +11,7 @@
 from __future__ import annotations
 
 import logging
+from math import isclose
 import re
 import time
 import warnings
@@ -28,7 +29,9 @@ from gymnasium import Env
 from gymnasium.spaces import Box, Dict, Discrete
 from joblib import load
 from qiskit import QuantumCircuit
-from qiskit.transpiler import CouplingMap, TranspileLayout
+from qiskit.circuit import StandardEquivalenceLibrary
+from qiskit.transpiler import CouplingMap, PassManager, TranspileLayout
+from qiskit.transpiler.passes import BasisTranslator
 
 from mqt.predictor.hellinger import get_hellinger_model_path
 from mqt.predictor.reward import (
@@ -67,6 +70,9 @@ class PredictorEnv(Env):
         max_steps: int | None = None,
         tracer_output_path: str | Path | None = None,
         mdp: MDPPolicy = "v3",
+        intermediate_reward: bool = True,
+        reward_scale: float = 1.0,
+        no_effect_penalty: float = -0.001,
     ) -> None:
         """Initializes the PredictorEnv object.
 
@@ -79,6 +85,11 @@ class PredictorEnv(Env):
             mdp: The MDP transition policy. ``v2`` is the original MQT Predictor
                 strategy. ``v3`` is the default and is permissive before layout while
                 preserving the established compilation structure afterwards.
+            intermediate_reward: Whether to reward changes to the figure of merit
+                before termination.
+            reward_scale: Multiplier applied to intermediate reward changes.
+            no_effect_penalty: Reward for optimization actions that do not improve
+                the figure of merit.
 
         Raises:
             ValueError: If ``mdp`` is unsupported, if the reward function is
@@ -96,6 +107,9 @@ class PredictorEnv(Env):
         self.path_training_circuits = path_training_circuits or get_path_training_circuits()
         self.max_steps = max_steps
         self.mdp = mdp
+        self.intermediate_reward = intermediate_reward
+        self.reward_scale = reward_scale
+        self.no_effect_penalty = no_effect_penalty
 
         self.action_set = {}
         self.actions_synthesis_indices = []
@@ -286,6 +300,11 @@ class PredictorEnv(Env):
         start_time = time.perf_counter()
         try:
             self.used_actions.append(action_name)
+            previous_reward = (
+                self._get_stepwise_reward()
+                if self.intermediate_reward and action != self.action_terminate_index
+                else None
+            )
             altered_qc = self.apply_action(action)
             action_duration = time.perf_counter() - start_time
         except Exception as exc:  # ruff:ignore[blind-except]
@@ -328,6 +347,9 @@ class PredictorEnv(Env):
         if action == self.action_terminate_index:
             reward_val = self.calculate_reward()
             done = True
+        elif previous_reward is not None:
+            reward_val = self._calculate_intermediate_reward(action, previous_reward)
+            done = False
         else:
             reward_val = 0
             done = False
@@ -383,6 +405,56 @@ class PredictorEnv(Env):
     def calculate_reward(self) -> float:
         """Calculates and returns the reward for the current state."""
         return self.get_fom(self.reward_function)
+
+    def _get_stepwise_reward(self) -> tuple[float, str]:
+        """Return the current reward and whether it is exact or approximate."""
+        if self.reward_function not in {"expected_fidelity", "estimated_success_probability"}:
+            return 0.0, "unavailable"
+
+        if self._current_synthesized and self._current_laid_out and self._current_routed:
+            return self.calculate_reward(), "exact"
+        return self._approximate_reward(), "approximate"
+
+    def _approximate_reward(self) -> float:
+        """Estimate a reward from the average error of translated native gates."""
+        circuit = PassManager(
+            [BasisTranslator(StandardEquivalenceLibrary, target_basis=self.device.operation_names)]
+        ).run(self.state.copy())
+        reward = 1.0
+
+        for instruction in circuit.data:
+            gate_name = instruction.operation.name
+            if gate_name in {"barrier", "measure"}:
+                continue
+
+            try:
+                properties = self.device[gate_name].values()
+            except KeyError:
+                return 0.0
+
+            errors = [
+                property.error for property in properties if property is not None and property.error is not None
+            ]
+            if not errors:
+                return 0.0
+            reward *= 1 - float(np.mean(errors))
+
+        return reward
+
+    def _calculate_intermediate_reward(self, action: int, previous_reward: tuple[float, str]) -> float:
+        """Calculate the shaped reward for a non-terminal action."""
+        previous_value, previous_kind = previous_reward
+        current_value, current_kind = self._get_stepwise_reward()
+        if previous_kind != current_kind:
+            return 0.0
+
+        delta = current_value - previous_value
+        if not isclose(delta, 0.0, abs_tol=1e-12):
+            return self.reward_scale * delta
+
+        if self.action_set[action].pass_type in {PassType.OPT, PassType.FINAL_OPT}:
+            return self.no_effect_penalty
+        return 0.0
 
     def render(self) -> None:
         """Renders the current state."""

--- a/src/mqt/predictor/rl/predictorenv.py
+++ b/src/mqt/predictor/rl/predictorenv.py
@@ -432,7 +432,11 @@ class PredictorEnv(Env):
             except KeyError:
                 return 0.0
 
-            errors = [property.error for property in properties if property is not None and property.error is not None]
+            errors = [
+                instruction_property.error
+                for instruction_property in properties
+                if instruction_property is not None and instruction_property.error is not None
+            ]
             if not errors:
                 return 0.0
             reward *= 1 - float(np.mean(errors))

--- a/src/mqt/predictor/rl/predictorenv.py
+++ b/src/mqt/predictor/rl/predictorenv.py
@@ -11,10 +11,10 @@
 from __future__ import annotations
 
 import logging
-from math import isclose
 import re
 import time
 import warnings
+from math import isclose
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Literal, get_args
 
@@ -417,9 +417,9 @@ class PredictorEnv(Env):
 
     def _approximate_reward(self) -> float:
         """Estimate a reward from the average error of translated native gates."""
-        circuit = PassManager(
-            [BasisTranslator(StandardEquivalenceLibrary, target_basis=self.device.operation_names)]
-        ).run(self.state.copy())
+        circuit = PassManager([
+            BasisTranslator(StandardEquivalenceLibrary, target_basis=self.device.operation_names)
+        ]).run(self.state.copy())
         reward = 1.0
 
         for instruction in circuit.data:
@@ -432,9 +432,7 @@ class PredictorEnv(Env):
             except KeyError:
                 return 0.0
 
-            errors = [
-                property.error for property in properties if property is not None and property.error is not None
-            ]
+            errors = [property.error for property in properties if property is not None and property.error is not None]
             if not errors:
                 return 0.0
             reward *= 1 - float(np.mean(errors))

--- a/src/mqt/predictor/rl/predictorenv.py
+++ b/src/mqt/predictor/rl/predictorenv.py
@@ -48,6 +48,7 @@ from mqt.predictor.rl.actions.qiskit_actions import is_qiskit_action_available, 
 from mqt.predictor.rl.actions.tket_actions import is_tket_action_available, run_tket_action
 from mqt.predictor.rl.helper import create_feature_dict, get_path_training_circuits, get_state_sample
 from mqt.predictor.rl.tracer import CompilationTracer, FigureOfMeritMetric, FigureOfMeritMetrics
+from mqt.predictor.utils import get_openqasm_gates_for_rl
 
 logger = logging.getLogger("mqt-predictor")
 
@@ -174,9 +175,14 @@ class PredictorEnv(Env):
         self.has_parameterized_gates = False
         self.rng = np.random.default_rng(10)
 
+        gate_spaces = {
+            gate: Box(low=0, high=1, shape=(1,), dtype=np.float32) for gate in get_openqasm_gates_for_rl()
+        }
         spaces: dict[str, Space] = {
             "num_qubits": Discrete(128),
             "depth": Discrete(1000000),
+            "measure": Box(low=0, high=1, shape=(1,), dtype=np.float32),
+            **gate_spaces,
             "program_communication": Box(low=0, high=1, shape=(1,), dtype=np.float32),
             "critical_depth": Box(low=0, high=1, shape=(1,), dtype=np.float32),
             "entanglement_ratio": Box(low=0, high=1, shape=(1,), dtype=np.float32),

--- a/src/mqt/predictor/rl/tracer.py
+++ b/src/mqt/predictor/rl/tracer.py
@@ -209,7 +209,7 @@ class CompilationTracer:
         reward: float,
         current_qc: QuantumCircuit,
         figures_of_merit: FigureOfMeritMetrics,
-        features: dict[str, int | NDArray[np.float32]],
+        features: dict[str, NDArray[np.float32]],
         synthesized: bool,
         laid_out: bool,
         routed: bool,
@@ -337,8 +337,6 @@ class CompilationTracer:
         )
 
     @staticmethod
-    def _extract_float(val: int | NDArray[np.float32]) -> float:
-        """Safely extracts a float from a scalar or a 1D NumPy array to satisfy linter requirements."""
-        if isinstance(val, int):
-            return float(val)
+    def _extract_float(val: NDArray[np.float32]) -> float:
+        """Extract a float from a one-element feature array."""
         return float(val.item())

--- a/src/mqt/predictor/utils.py
+++ b/src/mqt/predictor/utils.py
@@ -144,3 +144,41 @@ def calc_supermarq_features(
         parallelism,
         liveness,
     )
+
+
+def get_openqasm_gates_for_rl() -> list[str]:
+    """Return the OpenQASM gates used as normalized RL features.
+
+    Generic unitary gates and gates acting on more than two qubits are excluded
+    because they are not meaningful features for the RL action space.
+    """
+    return [
+        "cx",
+        "id",
+        "p",
+        "x",
+        "y",
+        "z",
+        "h",
+        "s",
+        "sdg",
+        "t",
+        "tdg",
+        "rx",
+        "ry",
+        "rz",
+        "sx",
+        "sxdg",
+        "cz",
+        "cy",
+        "swap",
+        "ch",
+        "crx",
+        "cry",
+        "crz",
+        "cp",
+        "cu3",
+        "csx",
+        "rxx",
+        "rzz",
+    ]

--- a/tests/compilation/test_predictor_rl.py
+++ b/tests/compilation/test_predictor_rl.py
@@ -160,7 +160,7 @@ def test_warning_for_unidirectional_device() -> None:
 def test_predictor_env_truncates_at_max_steps() -> None:
     """Test that the environment truncates episodes that hit the step limit."""
     device = get_device("ibm_falcon_27")
-    env = predictorenv_module.PredictorEnv(device=device, max_steps=1)
+    env = predictorenv_module.PredictorEnv(device=device, max_steps=1, intermediate_reward=False)
     qc = QuantumCircuit(1)
     qc.h(0)
     env.reset(qc)


### PR DESCRIPTION
🤖 *AI text below* 🤖

## Description

Replaces the discrete `num_qubits` and `depth` RL observations with one-element `float32` values in `[0, 1]`. Qubit count is scaled linearly and capped at 127; depth is `log1p`-scaled and capped at 999,999.

This prevents Stable-Baselines3 from expanding those values into large one-hot vectors and reduces the flattened policy input from 1,000,162 features to 36. Existing RL models must be retrained, and direct `PredictorEnv` observation consumers must handle the new array values.

This stacked PR depends on #760 and contains no phase/deadline observations, GNN changes, or local diagnostic tooling. Validated with `uvx nox -s lint`, the RL helper/tracer tests (7 passed), and an observation-schema smoke check.

## Checklist

- [x] The pull request only contains commits that are focused and relevant to this change.
- [ ] I have added appropriate tests that cover the new/changed functionality.
- [x] I have updated the documentation to reflect these changes.
- [x] I have added entries to the changelog for any noteworthy additions, changes, fixes, or removals.
- [x] I have added migration instructions to the upgrade guide (if needed).
- [x] The changes follow the project's style guidelines and introduce no new warnings.
- [ ] The changes are fully tested and pass the CI checks.
- [ ] I have reviewed my own code changes.

**If PR contains AI-assisted content:**

- [x] Any agent that created, edited, or submitted GitHub content was explicitly authorized for that scope, as required by our [AI Usage Guidelines](https://github.com/munich-quantum-toolkit/predictor/blob/main/docs/ai_usage.md).
- [x] Every agent-authored or agent-edited public text body begins with the visible disclosure `🤖 *AI text below* 🤖` (titles are exempt).
- [x] I have disclosed AI assistance in the PR description.
- [ ] I confirm that I have personally reviewed and understood all AI-generated content, and accept full responsibility for it.
