### PR TITLE
✨ Add missing BQSKit synthesis passes

### DIFF
--- a/src/mqt/predictor/rl/actions/bqskit_actions.py
+++ b/src/mqt/predictor/rl/actions/bqskit_actions.py
@@ -39,6 +39,8 @@ from bqskit.passes import (
     IfThenElsePass,
     LEAPSynthesisPass,
     ManyQuditGatesPredicate,
+    MGDPass,
+    QSDPass,
     QSearchSynthesisPass,
     RestoreMeasurements,
     SetModelPass,
@@ -308,6 +310,18 @@ def bqskit_synthesis_actions() -> list[Action]:
                 device,
                 IfThenElsePass(DiagonalPredicate(1e-9), WalshDiagonalSynthesisPass()),
             ),
+        ),
+        DeferredDeviceAction(
+            "QSDPass",
+            CompilationOrigin.BQSKIT,
+            PassType.SYNTHESIS,
+            transpile_pass=lambda device: _bqskit_partitioned_synthesis_factory(device, QSDPass()),
+        ),
+        DeferredDeviceAction(
+            "MGDPass",
+            CompilationOrigin.BQSKIT,
+            PassType.SYNTHESIS,
+            transpile_pass=lambda device: _bqskit_partitioned_synthesis_factory(device, MGDPass()),
         ),
         DeferredDeviceAction(
             "FullQSDPass",


### PR DESCRIPTION
🤖 *AI text below* 🤖

## Description

Adds the two BQSKit synthesis actions used by the paper prototype but missing from the production action registry:

- `QSDPass`
- `MGDPass`

Both actions reuse the existing partitioned-synthesis factory, including its established model, seed, partitioning, retargeting, and measurement handling. `FullQSDPass` remains a separate action.

This draft is stacked on #759. It intentionally contains only the raw action additions; documentation and new tests are deferred.

## Validation

- imported the action registry with BQSKit 1.2.1
- verified the action order around `WalshDiagonalSynthesisPass` and `FullQSDPass`
- `git diff --check`

## Checklist

- [x] The pull request only contains focused changes required for this feature.
- [ ] New tests and documentation are intentionally deferred while the feature stack is assembled.
- [x] I reviewed the complete base-to-head diff.

**If PR contains AI-assisted content:**

- [x] Any agent that created, edited, or submitted GitHub content was explicitly authorized for that scope.
- [x] Every agent-authored or agent-edited public text body begins with the visible disclosure `🤖 *AI text below* 🤖`.
- [ ] I confirm that I have personally reviewed and understood all AI-generated content, and accept full responsibility for it.
