### PR TITLE
🐛 Make RL circuit sampling seed-aware

### DIFF
--- a/src/mqt/predictor/rl/helper.py
+++ b/src/mqt/predictor/rl/helper.py
@@ -47,14 +47,14 @@ def get_state_sample(max_qubits: int, path_training_circuits: Path, rng: Generat
     Raises:
         RuntimeError: If no quantum circuit could be read from the training circuits folder.
     """
-    file_list = list(path_training_circuits.glob("*.qasm"))
+    file_list = sorted(path_training_circuits.glob("*.qasm"))
 
     path_zip = path_training_circuits / "training_data_compilation.zip"
     if len(file_list) == 0 and path_zip.exists():
         with zipfile.ZipFile(str(path_zip), "r") as zip_ref:
             zip_ref.extractall(path_training_circuits)
 
-        file_list = list(path_training_circuits.glob("*.qasm"))
+        file_list = sorted(path_training_circuits.glob("*.qasm"))
         assert len(file_list) > 0
 
     found_suitable_qc = False

--- a/src/mqt/predictor/rl/predictorenv.py
+++ b/src/mqt/predictor/rl/predictorenv.py
@@ -177,7 +177,6 @@ class PredictorEnv(Env):
         self.layout: TranspileLayout | None = None
 
         self.has_parameterized_gates = False
-        self.rng = np.random.default_rng(10)
 
         operation_spaces = {
             operation: Box(low=0, high=1, shape=(1,), dtype=np.float32) for operation in OBSERVATION_OPERATIONS
@@ -419,7 +418,11 @@ class PredictorEnv(Env):
             self.filename = str(qc)
             current_circuit_name = Path(str(qc)).stem
         else:
-            self.state, self.filename = get_state_sample(self.device.num_qubits, self.path_training_circuits, self.rng)
+            self.state, self.filename = get_state_sample(
+                self.device.num_qubits,
+                self.path_training_circuits,
+                self.np_random,
+            )
             current_circuit_name = Path(self.filename).stem
 
         self.action_space = Discrete(len(self.action_set.keys()))


### PR DESCRIPTION
🤖 *AI text below* 🤖

## Description

Makes RL training-circuit sampling follow Gymnasium's standard seed lifecycle.

`PredictorEnv` now uses `self.np_random`, which is initialized and reseeded by `Env.reset(seed=...)`, instead of a separate generator fixed to seed 10. Training-circuit paths are sorted before indexed sampling so equal seeds select equal circuits across filesystems.

Compiler-specific seeds, flat-policy defaults, ML estimator seeds, and experiment-only RNGs are unchanged because they already match the intended behavior or are outside this PR's scope.

This draft is stacked on #780. It intentionally contains only the raw seeding fix; documentation and new tests are deferred.

## Validation

- repeated `reset(seed=7)` selects the same training circuit
- complete audit of seed and RNG sites under `src/`
- `git diff --check`

## Checklist

- [x] The pull request only contains focused changes required for this fix.
- [ ] New tests and documentation are intentionally deferred while the feature stack is assembled.
- [x] I reviewed the complete base-to-head diff.

**If PR contains AI-assisted content:**

- [x] Any agent that created, edited, or submitted GitHub content was explicitly authorized for that scope.
- [x] Every agent-authored or agent-edited public text body begins with the visible disclosure `🤖 *AI text below* 🤖`.
- [ ] I confirm that I have personally reviewed and understood all AI-generated content, and accept full responsibility for it.
