### PR TITLE
✨ Add missing BQSKit RL synthesis actions

### DIFF
--- a/src/mqt/predictor/rl/actions/bqskit_actions.py
+++ b/src/mqt/predictor/rl/actions/bqskit_actions.py
@@ -39,6 +39,8 @@ from bqskit.passes import (
     IfThenElsePass,
     LEAPSynthesisPass,
     ManyQuditGatesPredicate,
+    MGDPass,
+    QSDPass,
     QSearchSynthesisPass,
     RestoreMeasurements,
     SetModelPass,
@@ -308,6 +310,18 @@ def bqskit_synthesis_actions() -> list[Action]:
                 device,
                 IfThenElsePass(DiagonalPredicate(1e-9), WalshDiagonalSynthesisPass()),
             ),
+        ),
+        DeferredDeviceAction(
+            "QSDPass",
+            CompilationOrigin.BQSKIT,
+            PassType.SYNTHESIS,
+            transpile_pass=lambda device: _bqskit_partitioned_synthesis_factory(device, QSDPass()),
+        ),
+        DeferredDeviceAction(
+            "MGDPass",
+            CompilationOrigin.BQSKIT,
+            PassType.SYNTHESIS,
+            transpile_pass=lambda device: _bqskit_partitioned_synthesis_factory(device, MGDPass()),
         ),
         DeferredDeviceAction(
             "FullQSDPass",


### PR DESCRIPTION
🤖 *AI text below* 🤖

## Description

Adds the two BQSKit synthesis actions present in the paper prototype but missing from the production action registry:

- `QSDPass`
- `MGDPass`

Both reuse the existing partitioned-synthesis factory, including its established block size, seed, retargeting, and measurement workflow. No other BQSKit behavior changes.

This draft is stacked on the Qiskit pass PR. Validated with lint and focused synthesis-action smoke checks.

Follow-up to #673

Part of #664

## Checklist

- [x] The diff is focused and reuses existing infrastructure.
- [x] Lint passes.
- [ ] I confirm that I have personally reviewed and understood all AI-generated content.

**If PR contains AI-assisted content:**

- [x] AI assistance was authorized and is disclosed.
- [x] This body begins with the required visible disclosure.

