### PR TITLE
🐛 Make RL circuit sampling reproducible

### DIFF
--- a/src/mqt/predictor/rl/helper.py
+++ b/src/mqt/predictor/rl/helper.py
@@ -47,14 +47,14 @@ def get_state_sample(max_qubits: int, path_training_circuits: Path, rng: Generat
     Raises:
         RuntimeError: If no quantum circuit could be read from the training circuits folder.
     """
-    file_list = list(path_training_circuits.glob("*.qasm"))
+    file_list = sorted(path_training_circuits.glob("*.qasm"))
 
     path_zip = path_training_circuits / "training_data_compilation.zip"
     if len(file_list) == 0 and path_zip.exists():
         with zipfile.ZipFile(str(path_zip), "r") as zip_ref:
             zip_ref.extractall(path_training_circuits)
 
-        file_list = list(path_training_circuits.glob("*.qasm"))
+        file_list = sorted(path_training_circuits.glob("*.qasm"))
         assert len(file_list) > 0
 
     found_suitable_qc = False

--- a/src/mqt/predictor/rl/predictorenv.py
+++ b/src/mqt/predictor/rl/predictorenv.py
@@ -177,7 +177,6 @@ class PredictorEnv(Env):
         self.layout: TranspileLayout | None = None
 
         self.has_parameterized_gates = False
-        self.rng = np.random.default_rng(10)
 
         operation_spaces = {
             operation: Box(low=0, high=1, shape=(1,), dtype=np.float32) for operation in OBSERVATION_OPERATIONS
@@ -419,7 +418,11 @@ class PredictorEnv(Env):
             self.filename = str(qc)
             current_circuit_name = Path(str(qc)).stem
         else:
-            self.state, self.filename = get_state_sample(self.device.num_qubits, self.path_training_circuits, self.rng)
+            self.state, self.filename = get_state_sample(
+                self.device.num_qubits,
+                self.path_training_circuits,
+                self.np_random,
+            )
             current_circuit_name = Path(self.filename).stem
 
         self.action_space = Discrete(len(self.action_set.keys()))


### PR DESCRIPTION
🤖 *AI text below* 🤖

## Description

Makes RL training-circuit sampling honor Gymnasium's seed lifecycle.

`PredictorEnv` now uses Gymnasium's `np_random`, so `reset(seed=...)` controls sampling, and candidate QASM paths are sorted before indexed selection to make identical seeds reproducible across filesystems.

This draft is stacked on the TKET pass PR. It does not change BQSKit's established fixed pass seed or unrelated ML estimators. Validated with repository lint and focused sampling smoke checks.

Part of #664

## Checklist

- [x] The diff is focused and reuses Gymnasium's RNG.
- [x] Lint passes.
- [ ] I confirm that I have personally reviewed and understood all AI-generated content.

**If PR contains AI-assisted content:**

- [x] AI assistance was authorized and is disclosed.
- [x] This body begins with the required visible disclosure.
