### PR TITLE
✨ Evaluate stochastic RL pass candidates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ releases may include breaking changes.
   and include measurements in the shared ML feature schema ([#758])
   ([**@flowerthrower**])
 - ✨ Evaluate configurable repeated candidates for stochastic Qiskit RL actions
-  and retain the highest-scoring result ([#757]) ([**@flowerthrower**])
+  and retain the highest-scoring result ([#791]) ([**@flowerthrower**])
 - 👷 Enable testing on Python 3.14 ([#488]) ([**@denialhaag**])
 - ✨ Add selectable `v2` and `v3` RL MDP strategies, make `v3` the default, and
   use the selected strategy in compilation traces and model artifact names
@@ -108,7 +108,7 @@ for previous changelogs._
 [#784]: https://github.com/munich-quantum-toolkit/predictor/pull/784
 [#785]: https://github.com/munich-quantum-toolkit/predictor/pull/785
 [#758]: https://github.com/munich-quantum-toolkit/predictor/pull/758
-[#757]: https://github.com/munich-quantum-toolkit/predictor/pull/757
+[#791]: https://github.com/munich-quantum-toolkit/predictor/pull/791
 [#755]: https://github.com/munich-quantum-toolkit/predictor/pull/755
 [#731]: https://github.com/munich-quantum-toolkit/predictor/pull/731
 [#714]: https://github.com/munich-quantum-toolkit/predictor/pull/714

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ releases may include breaking changes.
 - ✨ Expand the RL observation with normalized OpenQASM operation frequencies
   and include measurements in the shared ML feature schema ([#758])
   ([**@flowerthrower**])
+- ✨ Evaluate configurable repeated candidates for stochastic Qiskit RL actions
+  and retain the highest-scoring result ([#757]) ([**@flowerthrower**])
 - 👷 Enable testing on Python 3.14 ([#488]) ([**@denialhaag**])
 - ✨ Add selectable `v2` and `v3` RL MDP strategies, make `v3` the default, and
   use the selected strategy in compilation traces and model artifact names
@@ -106,6 +108,7 @@ for previous changelogs._
 [#784]: https://github.com/munich-quantum-toolkit/predictor/pull/784
 [#785]: https://github.com/munich-quantum-toolkit/predictor/pull/785
 [#758]: https://github.com/munich-quantum-toolkit/predictor/pull/758
+[#757]: https://github.com/munich-quantum-toolkit/predictor/pull/757
 [#755]: https://github.com/munich-quantum-toolkit/predictor/pull/755
 [#731]: https://github.com/munich-quantum-toolkit/predictor/pull/731
 [#714]: https://github.com/munich-quantum-toolkit/predictor/pull/714

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -44,6 +44,14 @@ Starting with this release, MQT Predictor no longer supports Python 3.10. As a
 result, MQT Predictor is no longer tested under Python 3.10 and requires Python
 3.11 or later.
 
+### Repeated stochastic Qiskit actions
+
+The stochastic `QiskitSabreMapping` action now evaluates 20 candidates by
+default and retains the candidate with the best configured figure of merit. This
+can increase compilation time and change the selected circuit. Set
+`stochastic_action_trials=1` when constructing `PredictorEnv` to retain the
+previous single-attempt behavior.
+
 ### Atomic BQSKit compilation actions
 
 The composite actions `BQSKitO2`, `BQSKitSynthesis`, and `BQSKitMapping` are no

--- a/src/mqt/predictor/rl/actions/base.py
+++ b/src/mqt/predictor/rl/actions/base.py
@@ -52,6 +52,7 @@ class Action:
         preserves_layout: Whether action preserves existing layout.
         preserves_routing: Whether action preserves existing routing.
         preserves_synthesis: Whether action preserves synthesis state.
+        stochastic: Whether repeated execution can yield different results.
     """
 
     name: str
@@ -61,6 +62,7 @@ class Action:
     preserves_layout: bool = False
     preserves_routing: bool = False
     preserves_synthesis: bool = False
+    stochastic: bool = False
 
 
 @dataclass

--- a/src/mqt/predictor/rl/actions/qiskit_actions.py
+++ b/src/mqt/predictor/rl/actions/qiskit_actions.py
@@ -461,7 +461,7 @@ def run_qiskit_action(
             action,
             circuit,
             device,
-            deepcopy(layout),
+            deepcopy(layout) if attempts > 1 else layout,
             input_qubit_count,
         )
         if score is None:
@@ -488,7 +488,6 @@ def _run_qiskit_action_once(
     input_qubit_count: int | None,
 ) -> tuple[QuantumCircuit, TranspileLayout | None]:
     """Run one Qiskit action attempt and update its layout metadata."""
-    # Build the concrete Qiskit pass list for a single attempt.
     if action.name == "QiskitO3" and isinstance(action, DeferredDeviceAction):
         factory = cast("Callable[[list[str], CouplingMap | None], list[Task]]", action.transpile_pass)
         passes = factory(device.operation_names, CouplingMap(device.build_coupling_map()) if layout else None)

--- a/src/mqt/predictor/rl/actions/qiskit_actions.py
+++ b/src/mqt/predictor/rl/actions/qiskit_actions.py
@@ -10,8 +10,8 @@
 
 from __future__ import annotations
 
-from copy import deepcopy
 import logging
+from copy import deepcopy
 from typing import TYPE_CHECKING, cast
 
 from qiskit.circuit import StandardEquivalenceLibrary

--- a/src/mqt/predictor/rl/actions/qiskit_actions.py
+++ b/src/mqt/predictor/rl/actions/qiskit_actions.py
@@ -10,6 +10,7 @@
 
 from __future__ import annotations
 
+from copy import deepcopy
 import logging
 from typing import TYPE_CHECKING, cast
 
@@ -358,6 +359,7 @@ def qiskit_mapping_action() -> Action:
         "QiskitSabreMapping",
         CompilationOrigin.QISKIT,
         PassType.MAPPING,
+        stochastic=True,
         transpile_pass=lambda device: cast(
             "list[Task]", [SabreLayout(coupling_map=CouplingMap(device.build_coupling_map()), skip_routing=False)]
         ),
@@ -442,9 +444,51 @@ def run_qiskit_action(
     device: Target,
     layout: TranspileLayout | None,
     input_qubit_count: int | None = None,
+    stochastic_action_trials: int = 1,
+    score: Callable[[QuantumCircuit], float] | None = None,
 ) -> tuple[QuantumCircuit, TranspileLayout | None]:
-    """Apply a Qiskit action and return the updated circuit and layout metadata."""
-    # Build the concrete Qiskit pass list for given action.
+    """Apply a Qiskit action and return the updated circuit and layout metadata.
+
+    Stochastic actions are evaluated repeatedly when a score function is
+    supplied. The highest-scoring result is retained together with its layout.
+    """
+    attempts = stochastic_action_trials if action.stochastic and score is not None else 1
+    best_result: tuple[QuantumCircuit, TranspileLayout | None] | None = None
+    best_score: float | None = None
+
+    for _ in range(max(1, attempts)):
+        altered_qc, candidate_layout = _run_qiskit_action_once(
+            action,
+            circuit,
+            device,
+            deepcopy(layout),
+            input_qubit_count,
+        )
+        if score is None:
+            return altered_qc, candidate_layout
+
+        try:
+            candidate_score = score(altered_qc)
+        except Exception:  # ruff:ignore[blind-except]
+            logger.warning("Could not evaluate stochastic action %s; using swap count instead.", action.name)
+            candidate_score = -float(altered_qc.count_ops().get("swap", 0))
+        if best_score is None or candidate_score > best_score:
+            best_result = altered_qc, candidate_layout
+            best_score = candidate_score
+
+    assert best_result is not None
+    return best_result
+
+
+def _run_qiskit_action_once(
+    action: Action,
+    circuit: QuantumCircuit,
+    device: Target,
+    layout: TranspileLayout | None,
+    input_qubit_count: int | None,
+) -> tuple[QuantumCircuit, TranspileLayout | None]:
+    """Run one Qiskit action attempt and update its layout metadata."""
+    # Build the concrete Qiskit pass list for a single attempt.
     if action.name == "QiskitO3" and isinstance(action, DeferredDeviceAction):
         factory = cast("Callable[[list[str], CouplingMap | None], list[Task]]", action.transpile_pass)
         passes = factory(device.operation_names, CouplingMap(device.build_coupling_map()) if layout else None)

--- a/src/mqt/predictor/rl/actions/qiskit_actions.py
+++ b/src/mqt/predictor/rl/actions/qiskit_actions.py
@@ -452,18 +452,25 @@ def run_qiskit_action(
     Stochastic actions are evaluated repeatedly when a score function is
     supplied. The highest-scoring result is retained together with its layout.
     """
-    attempts = stochastic_action_trials if action.stochastic and score is not None else 1
+    stochastic_run = action.stochastic and score is not None
+    attempts = stochastic_action_trials if stochastic_run else 1
     best_result: tuple[QuantumCircuit, TranspileLayout | None] | None = None
     best_score: float | None = None
 
-    for _ in range(max(1, attempts)):
-        altered_qc, candidate_layout = _run_qiskit_action_once(
-            action,
-            circuit,
-            device,
-            deepcopy(layout) if attempts > 1 else layout,
-            input_qubit_count,
-        )
+    for attempt in range(max(1, attempts)):
+        try:
+            altered_qc, candidate_layout = _run_qiskit_action_once(
+                action,
+                circuit,
+                device,
+                deepcopy(layout) if stochastic_run else layout,
+                input_qubit_count,
+            )
+        except Exception:
+            if not stochastic_run:
+                raise
+            logger.exception("Stochastic action %s failed on attempt %d.", action.name, attempt + 1)
+            continue
         if score is None:
             return altered_qc, candidate_layout
 
@@ -476,8 +483,10 @@ def run_qiskit_action(
             best_result = altered_qc, candidate_layout
             best_score = candidate_score
 
-    assert best_result is not None
-    return best_result
+    if best_result is not None:
+        return best_result
+    logger.error("All attempts for stochastic action %s failed.", action.name)
+    return circuit, layout
 
 
 def _run_qiskit_action_once(

--- a/src/mqt/predictor/rl/actions/qiskit_actions.py
+++ b/src/mqt/predictor/rl/actions/qiskit_actions.py
@@ -323,6 +323,7 @@ def qiskit_routing_actions() -> list[Action]:
             "SabreSwap",
             CompilationOrigin.QISKIT,
             PassType.ROUTING,
+            stochastic=True,
             transpile_pass=lambda device: cast(
                 "list[Task]", [SabreSwap(coupling_map=CouplingMap(device.build_coupling_map()), heuristic="decay")]
             ),

--- a/src/mqt/predictor/rl/actions/qiskit_actions.py
+++ b/src/mqt/predictor/rl/actions/qiskit_actions.py
@@ -467,6 +467,8 @@ def run_qiskit_action(
                 deepcopy(layout) if stochastic_run else layout,
                 input_qubit_count,
             )
+        except TimeoutError:
+            raise
         except Exception:
             if not stochastic_run:
                 raise
@@ -477,6 +479,8 @@ def run_qiskit_action(
 
         try:
             candidate_score = score(altered_qc)
+        except TimeoutError:
+            raise
         except Exception:  # ruff:ignore[blind-except]
             logger.warning("Could not evaluate stochastic action %s; using swap count instead.", action.name)
             candidate_score = -float(altered_qc.count_ops().get("swap", 0))

--- a/src/mqt/predictor/rl/predictorenv.py
+++ b/src/mqt/predictor/rl/predictorenv.py
@@ -114,6 +114,7 @@ class PredictorEnv(Env):
         max_steps: int | None = None,
         tracer_output_path: str | Path | None = None,
         mdp: MDPPolicy = "v3",
+        stochastic_action_trials: int = 20,
         pass_timeout: float | None = None,
     ) -> None:
         """Initializes the PredictorEnv object.
@@ -127,6 +128,8 @@ class PredictorEnv(Env):
             mdp: The MDP transition policy. ``v2`` is the original MQT Predictor
                 strategy. ``v3`` is the default and is permissive before layout while
                 preserving the established compilation structure afterwards.
+            stochastic_action_trials: Number of attempts used to select the best
+                result from a stochastic action.
             pass_timeout: Maximum duration in seconds for one compilation pass.
                 Defaults to None, which disables pass timeouts.
 
@@ -143,10 +146,14 @@ class PredictorEnv(Env):
         if mdp not in MDP_POLICIES:
             msg = f"Unsupported MDP policy: {mdp}."
             raise ValueError(msg)
+        if stochastic_action_trials < 1:
+            msg = "stochastic_action_trials must be at least one."
+            raise ValueError(msg)
 
         self.path_training_circuits = path_training_circuits or get_path_training_circuits()
         self.max_steps = max_steps
         self.mdp = mdp
+        self.stochastic_action_trials = stochastic_action_trials
         self.pass_timeout = pass_timeout
 
         self.action_set = {}
@@ -620,6 +627,8 @@ class PredictorEnv(Env):
                 device=self.device,
                 layout=self.layout,
                 input_qubit_count=self.num_qubits_uncompiled_circuit,
+                stochastic_action_trials=self.stochastic_action_trials,
+                score=self._score_circuit if action.stochastic else None,
             )
         elif action.origin == CompilationOrigin.TKET:
             altered_qc, self.layout = run_tket_action(
@@ -640,6 +649,19 @@ class PredictorEnv(Env):
             raise ValueError(msg)
 
         return altered_qc
+
+    def _score_circuit(self, circuit: QuantumCircuit) -> float:
+        """Calculate the configured figure of merit for an action candidate."""
+        if self.reward_function == "expected_fidelity":
+            return expected_fidelity(circuit, self.device)
+        if self.reward_function == "estimated_success_probability":
+            return estimated_success_probability(circuit, self.device)
+        if self.reward_function == "estimated_hellinger_distance":
+            return estimated_hellinger_distance(circuit, self.device, self.hellinger_model)
+        if self.reward_function == "critical_depth":
+            return crit_depth(circuit)
+        msg = f"No implementation for reward function {self.reward_function}."
+        raise NotImplementedError(msg)
 
     def is_circuit_laid_out(self, circuit: QuantumCircuit, layout: TranspileLayout | Layout) -> bool:
         """True if every logical qubit in the circuit has a physical assignment."""

--- a/src/mqt/predictor/rl/predictorenv.py
+++ b/src/mqt/predictor/rl/predictorenv.py
@@ -34,7 +34,9 @@ from gymnasium import Env
 from gymnasium.spaces import Box, Dict, Discrete
 from joblib import load
 from qiskit import QuantumCircuit
-from qiskit.transpiler import CouplingMap, TranspileLayout
+from qiskit.circuit import StandardEquivalenceLibrary
+from qiskit.transpiler import CouplingMap, PassManager, TranspileLayout
+from qiskit.transpiler.passes import BasisTranslator
 
 from mqt.predictor.hellinger import get_hellinger_model_path
 from mqt.predictor.reward import (
@@ -652,14 +654,17 @@ class PredictorEnv(Env):
 
     def _score_circuit(self, circuit: QuantumCircuit) -> float:
         """Calculate the configured figure of merit for an action candidate."""
+        scoring_circuit = PassManager(
+            [BasisTranslator(StandardEquivalenceLibrary, target_basis=self.device.operation_names)]
+        ).run(circuit.copy())
         if self.reward_function == "expected_fidelity":
-            return expected_fidelity(circuit, self.device)
+            return expected_fidelity(scoring_circuit, self.device)
         if self.reward_function == "estimated_success_probability":
-            return estimated_success_probability(circuit, self.device)
+            return estimated_success_probability(scoring_circuit, self.device)
         if self.reward_function == "estimated_hellinger_distance":
-            return estimated_hellinger_distance(circuit, self.device, self.hellinger_model)
+            return estimated_hellinger_distance(scoring_circuit, self.device, self.hellinger_model)
         if self.reward_function == "critical_depth":
-            return crit_depth(circuit)
+            return crit_depth(scoring_circuit)
         msg = f"No implementation for reward function {self.reward_function}."
         raise NotImplementedError(msg)
 

--- a/src/mqt/predictor/rl/predictorenv.py
+++ b/src/mqt/predictor/rl/predictorenv.py
@@ -654,9 +654,9 @@ class PredictorEnv(Env):
 
     def _score_circuit(self, circuit: QuantumCircuit) -> float:
         """Calculate the configured figure of merit for an action candidate."""
-        scoring_circuit = PassManager(
-            [BasisTranslator(StandardEquivalenceLibrary, target_basis=self.device.operation_names)]
-        ).run(circuit.copy())
+        scoring_circuit = PassManager([
+            BasisTranslator(StandardEquivalenceLibrary, target_basis=self.device.operation_names)
+        ]).run(circuit.copy())
         if self.reward_function == "expected_fidelity":
             return expected_fidelity(scoring_circuit, self.device)
         if self.reward_function == "estimated_success_probability":


### PR DESCRIPTION
🤖 *AI text below* 🤖

## Description

Evaluates repeated candidates for Qiskit RL actions marked as stochastic and retains the candidate with the best configured figure of merit. Candidates are translated to the target basis before scoring; supported scoring failures fall back to minimizing inserted SWAPs.

`PredictorEnv.stochastic_action_trials` configures the number of attempts and defaults to 20. `QiskitSabreMapping` and the `SabreSwap` action introduced by #785 use this path. A failed candidate does not abort the episode: the remaining attempts continue, and an all-failed run leaves the circuit unchanged. Pass and scoring timeouts are re-raised so the timeout layer can truncate immediately rather than continuing unbounded trials. Set the trial count to 1 to retain single-attempt selection.

This is position 9 of the stack. It depends on the timeout PR #789 and is followed by the GNN PR #788.

Validated with repository lint, focused RL checks, and direct pass- and scoring-timeout smokes.

Fixes #667

Part of #664

## Checklist

- [x] The pull request only contains commits that are focused and relevant to this change.
- [x] I have updated the documentation to reflect these changes.
- [x] I have added entries to the changelog for noteworthy behavior changes.
- [x] I have added migration instructions to the upgrade guide.
- [x] The changes follow the project's style guidelines and introduce no new warnings.
- [x] I have reviewed my own code changes.

**If PR contains AI-assisted content:**

- [x] Any agent that created, edited, or submitted GitHub content was explicitly authorized for that scope, as required by our [AI Usage Guidelines](https://github.com/munich-quantum-toolkit/predictor/blob/main/docs/ai_usage.md).
- [x] Every agent-authored or agent-edited public text body begins with the visible disclosure `🤖 *AI text below* 🤖` (titles are exempt).
- [x] I have disclosed AI assistance in the PR description.
- [ ] I confirm that I have personally reviewed and understood all AI-generated content, and accept full responsibility for it.

