### PR TITLE
✨ Add Qiskit and stochastic RL actions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,9 +12,10 @@ releases may include breaking changes.
 
 ### Added
 
-- ✨ Expand and compact the RL observation with normalized OpenQASM operation
-  frequencies and one-element `float32` qubit-count and depth arrays, and
-  include measurements in the shared ML feature schema ([#758])
+- ✨ Encode the RL qubit-count and depth observations as normalized
+  one-element `float32` arrays ([#784]) ([**@flowerthrower**])
+- ✨ Expand the RL observation with normalized OpenQASM operation frequencies
+  and include measurements in the shared ML feature schema ([#758])
   ([**@flowerthrower**])
 - 👷 Enable testing on Python 3.14 ([#488]) ([**@denialhaag**])
 - ✨ Add selectable `v2` and `v3` RL MDP strategies, make `v3` the default, and
@@ -93,6 +94,7 @@ for previous changelogs._
 
 [#773]: https://github.com/munich-quantum-toolkit/predictor/pull/771
 [#769]: https://github.com/munich-quantum-toolkit/predictor/pull/769
+[#784]: https://github.com/munich-quantum-toolkit/predictor/pull/784
 [#758]: https://github.com/munich-quantum-toolkit/predictor/pull/758
 [#755]: https://github.com/munich-quantum-toolkit/predictor/pull/755
 [#731]: https://github.com/munich-quantum-toolkit/predictor/pull/731

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,9 @@ releases may include breaking changes.
 
 ### Added
 
-- ✨ Add Qiskit's `SabreSwap` pass to the RL routing actions ([#759])
+- ✨ Add Qiskit's `TrivialLayout`, `ElidePermutations`, `SabreSwap`,
+  `BasicSwap`, `LookaheadSwap`, `GateDirection`, `RemoveIdentityEquivalent`, and
+  `Optimize1qGatesSimpleCommutation` passes to the RL actions ([#759])
   ([**@flowerthrower**])
 - ✨ Encode the RL qubit-count and depth observations as normalized one-element
   `float32` arrays ([#784]) ([**@flowerthrower**])
@@ -26,6 +28,8 @@ releases may include breaking changes.
 
 ### Changed
 
+- 🐛 Make the `OptimizeCliffords` RL action collect standard Clifford gates
+  before optimizing them ([#759]) ([**@flowerthrower**])
 - 🔥 Drop support for Python 3.10 ([#773]) ([**@denialhaag**])
 - ♻️ Split RL actions package into `base` and `registry` modules ([#769])
   ([**@denialhaag**])

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ releases may include breaking changes.
 ### Added
 
 - ✨ Add Qiskit's `TrivialLayout`, `ElidePermutations`, `SabreSwap`,
-  `BasicSwap`, `LookaheadSwap`, `GateDirection`, `RemoveIdentityEquivalent`, and
+  `BasicSwap`, `LookaheadSwap`, `RemoveIdentityEquivalent`, and
   `Optimize1qGatesSimpleCommutation` passes to the RL actions ([#759])
   ([**@flowerthrower**])
 - ✨ Encode the RL qubit-count and depth observations as normalized one-element

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ releases may include breaking changes.
 - ✨ Expand the RL observation with normalized OpenQASM operation frequencies
   and include measurements in the shared ML feature schema ([#758])
   ([**@flowerthrower**])
+- ✨ Evaluate configurable repeated candidates for stochastic Qiskit RL actions
+  and retain the highest-scoring result ([#757]) ([**@flowerthrower**])
 - 👷 Enable testing on Python 3.14 ([#488]) ([**@denialhaag**])
 - ✨ Add selectable `v2` and `v3` RL MDP strategies, make `v3` the default, and
   use the selected strategy in compilation traces and model artifact names
@@ -103,6 +105,7 @@ for previous changelogs._
 [#784]: https://github.com/munich-quantum-toolkit/predictor/pull/784
 [#785]: https://github.com/munich-quantum-toolkit/predictor/pull/785
 [#758]: https://github.com/munich-quantum-toolkit/predictor/pull/758
+[#757]: https://github.com/munich-quantum-toolkit/predictor/pull/757
 [#755]: https://github.com/munich-quantum-toolkit/predictor/pull/755
 [#731]: https://github.com/munich-quantum-toolkit/predictor/pull/731
 [#714]: https://github.com/munich-quantum-toolkit/predictor/pull/714

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ releases may include breaking changes.
 
 - ✨ Add Qiskit's `TrivialLayout`, `ElidePermutations`, `SabreSwap`,
   `BasicSwap`, `LookaheadSwap`, `RemoveIdentityEquivalent`, and
-  `Optimize1qGatesSimpleCommutation` passes to the RL actions ([#759])
+  `Optimize1qGatesSimpleCommutation` passes to the RL actions ([#785])
   ([**@flowerthrower**])
 - ✨ Encode the RL qubit-count and depth observations as normalized one-element
   `float32` arrays ([#784]) ([**@flowerthrower**])
@@ -29,7 +29,7 @@ releases may include breaking changes.
 ### Changed
 
 - 🐛 Make the `OptimizeCliffords` RL action collect standard Clifford gates
-  before optimizing them ([#759]) ([**@flowerthrower**])
+  before optimizing them ([#785]) ([**@flowerthrower**])
 - 🔥 Drop support for Python 3.10 ([#773]) ([**@denialhaag**])
 - ♻️ Split RL actions package into `base` and `registry` modules ([#769])
   ([**@denialhaag**])
@@ -101,7 +101,7 @@ for previous changelogs._
 [#773]: https://github.com/munich-quantum-toolkit/predictor/pull/771
 [#769]: https://github.com/munich-quantum-toolkit/predictor/pull/769
 [#784]: https://github.com/munich-quantum-toolkit/predictor/pull/784
-[#759]: https://github.com/munich-quantum-toolkit/predictor/pull/759
+[#785]: https://github.com/munich-quantum-toolkit/predictor/pull/785
 [#758]: https://github.com/munich-quantum-toolkit/predictor/pull/758
 [#755]: https://github.com/munich-quantum-toolkit/predictor/pull/755
 [#731]: https://github.com/munich-quantum-toolkit/predictor/pull/731

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ releases may include breaking changes.
 
 ### Added
 
+- ✨ Add Qiskit's `SabreSwap` pass to the RL routing actions ([#759])
+  ([**@flowerthrower**])
 - ✨ Encode the RL qubit-count and depth observations as normalized one-element
   `float32` arrays ([#784]) ([**@flowerthrower**])
 - ✨ Expand the RL observation with normalized OpenQASM operation frequencies
@@ -95,6 +97,7 @@ for previous changelogs._
 [#773]: https://github.com/munich-quantum-toolkit/predictor/pull/771
 [#769]: https://github.com/munich-quantum-toolkit/predictor/pull/769
 [#784]: https://github.com/munich-quantum-toolkit/predictor/pull/784
+[#759]: https://github.com/munich-quantum-toolkit/predictor/pull/759
 [#758]: https://github.com/munich-quantum-toolkit/predictor/pull/758
 [#755]: https://github.com/munich-quantum-toolkit/predictor/pull/755
 [#731]: https://github.com/munich-quantum-toolkit/predictor/pull/731

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,8 @@ releases may include breaking changes.
 
 ### Added
 
-- ✨ Encode the RL qubit-count and depth observations as normalized
-  one-element `float32` arrays ([#784]) ([**@flowerthrower**])
+- ✨ Encode the RL qubit-count and depth observations as normalized one-element
+  `float32` arrays ([#784]) ([**@flowerthrower**])
 - ✨ Expand the RL observation with normalized OpenQASM operation frequencies
   and include measurements in the shared ML feature schema ([#758])
   ([**@flowerthrower**])

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,9 @@ releases may include breaking changes.
 
 ### Added
 
-- ✨ Expand the RL observation with normalized OpenQASM operation frequencies
-  and include measurements in the shared ML feature schema ([#758])
+- ✨ Expand and compact the RL observation with normalized OpenQASM operation
+  frequencies and one-element `float32` qubit-count and depth arrays, and
+  include measurements in the shared ML feature schema ([#758])
   ([**@flowerthrower**])
 - 👷 Enable testing on Python 3.14 ([#488]) ([**@denialhaag**])
 - ✨ Add selectable `v2` and `v3` RL MDP strategies, make `v3` the default, and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ releases may include breaking changes.
   and include measurements in the shared ML feature schema ([#758])
   ([**@flowerthrower**])
 - ✨ Evaluate configurable repeated candidates for stochastic Qiskit RL actions
-  and retain the highest-scoring result ([#757]) ([**@flowerthrower**])
+  and retain the highest-scoring result ([#791]) ([**@flowerthrower**])
 - 👷 Enable testing on Python 3.14 ([#488]) ([**@denialhaag**])
 - ✨ Add selectable `v2` and `v3` RL MDP strategies, make `v3` the default, and
   use the selected strategy in compilation traces and model artifact names
@@ -105,7 +105,7 @@ for previous changelogs._
 [#784]: https://github.com/munich-quantum-toolkit/predictor/pull/784
 [#785]: https://github.com/munich-quantum-toolkit/predictor/pull/785
 [#758]: https://github.com/munich-quantum-toolkit/predictor/pull/758
-[#757]: https://github.com/munich-quantum-toolkit/predictor/pull/757
+[#791]: https://github.com/munich-quantum-toolkit/predictor/pull/791
 [#755]: https://github.com/munich-quantum-toolkit/predictor/pull/755
 [#731]: https://github.com/munich-quantum-toolkit/predictor/pull/731
 [#714]: https://github.com/munich-quantum-toolkit/predictor/pull/714

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -11,8 +11,7 @@ of changes including minor and patch releases, please refer to the
 The RL action space now includes the following Qiskit passes:
 
 - the `TrivialLayout` and `ElidePermutations` layout actions;
-- the `SabreSwap`, `BasicSwap`, `LookaheadSwap`, and `GateDirection` routing
-  actions; and
+- the `SabreSwap`, `BasicSwap`, and `LookaheadSwap` routing actions; and
 - the `RemoveIdentityEquivalent` and `Optimize1qGatesSimpleCommutation`
   optimization actions.
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -6,11 +6,15 @@ of changes including minor and patch releases, please refer to the
 
 ## [Unreleased]
 
-### RL operation features
+### RL observation features
 
 The RL observation now includes normalized frequencies for supported OpenQASM
-gates and measurements. Existing RL models must be retrained, and code that
-consumes `PredictorEnv` observations directly must handle the additional keys.
+gates and measurements. The `num_qubits` and `depth` entries are now one-element
+`float32` arrays in `[0, 1]` instead of discrete integers. The qubit count is
+linearly scaled by the target device's qubit count; the depth is `log1p`-scaled
+and capped at 999,999. Existing RL models must be retrained, and code that
+consumes `PredictorEnv` observations directly must handle the expanded schema
+and array values.
 
 ### End of support for Python 3.10
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -6,15 +6,19 @@ of changes including minor and patch releases, please refer to the
 
 ## [Unreleased]
 
-### RL observation features
+### Compact scalar RL observations
 
-The RL observation now includes normalized frequencies for supported OpenQASM
-gates and measurements. The `num_qubits` and `depth` entries are now one-element
+The `num_qubits` and `depth` entries in RL observations are now one-element
 `float32` arrays in `[0, 1]` instead of discrete integers. The qubit count is
 linearly scaled by the target device's qubit count; the depth is `log1p`-scaled
 and capped at 999,999. Existing RL models must be retrained, and code that
-consumes `PredictorEnv` observations directly must handle the expanded schema
-and array values.
+consumes `PredictorEnv` observations directly must handle the new array values.
+
+### RL operation features
+
+The RL observation now includes normalized frequencies for supported OpenQASM
+gates and measurements. Existing RL models must be retrained, and code that
+consumes `PredictorEnv` observations directly must handle the additional keys.
 
 ### End of support for Python 3.10
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -44,6 +44,14 @@ Starting with this release, MQT Predictor no longer supports Python 3.10. As a
 result, MQT Predictor is no longer tested under Python 3.10 and requires Python
 3.11 or later.
 
+### Repeated stochastic Qiskit actions
+
+The stochastic `QiskitSabreMapping` action now evaluates 20 candidates by
+default and retains the candidate with the best configured figure of merit. This
+can increase compilation time and change the selected circuit. Set
+`stochastic_action_trials=1` when constructing `PredictorEnv` to retain the
+previous single-attempt behavior.
+
 ### Atomic BQSKit compilation actions
 
 The composite actions `BQSKitO2`, `BQSKitSynthesis`, and `BQSKitMapping` are no

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -6,6 +6,13 @@ of changes including minor and patch releases, please refer to the
 
 ## [Unreleased]
 
+### Qiskit SABRE routing action
+
+The RL action space now includes Qiskit's `SabreSwap` routing pass. Existing RL
+models must be retrained because the action-space size and the indices of later
+actions have changed. Code that persists or selects actions by numeric index
+must be updated.
+
 ### Compact scalar RL observations
 
 The `num_qubits` and `depth` entries in RL observations are now one-element

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -6,12 +6,24 @@ of changes including minor and patch releases, please refer to the
 
 ## [Unreleased]
 
-### Qiskit SABRE routing action
+### Expanded Qiskit action set
 
-The RL action space now includes Qiskit's `SabreSwap` routing pass. Existing RL
-models must be retrained because the action-space size and the indices of later
-actions have changed. Code that persists or selects actions by numeric index
-must be updated.
+The RL action space now includes the following Qiskit passes:
+
+- the `TrivialLayout` and `ElidePermutations` layout actions;
+- the `SabreSwap`, `BasicSwap`, `LookaheadSwap`, and `GateDirection` routing
+  actions; and
+- the `RemoveIdentityEquivalent` and `Optimize1qGatesSimpleCommutation`
+  optimization actions.
+
+`ElidePermutations` establishes a trivial layout in the same action so its
+output permutation remains part of the canonical layout. `OptimizeCliffords` now
+collects standard Clifford gates before optimizing and decomposes the result for
+subsequent passes.
+
+Existing RL models must be retrained because the action-space size and the
+indices of later actions have changed. Code that persists or selects actions by
+numeric index must be updated.
 
 ### Compact scalar RL observations
 

--- a/src/mqt/predictor/rl/actions/base.py
+++ b/src/mqt/predictor/rl/actions/base.py
@@ -52,6 +52,7 @@ class Action:
         preserves_layout: Whether action preserves existing layout.
         preserves_routing: Whether action preserves existing routing.
         preserves_synthesis: Whether action preserves synthesis state.
+        stochastic: Whether repeated execution can yield different results.
     """
 
     name: str
@@ -61,6 +62,7 @@ class Action:
     preserves_layout: bool = False
     preserves_routing: bool = False
     preserves_synthesis: bool = False
+    stochastic: bool = False
 
 
 @dataclass

--- a/src/mqt/predictor/rl/actions/qiskit_actions.py
+++ b/src/mqt/predictor/rl/actions/qiskit_actions.py
@@ -461,7 +461,7 @@ def run_qiskit_action(
             action,
             circuit,
             device,
-            deepcopy(layout),
+            deepcopy(layout) if attempts > 1 else layout,
             input_qubit_count,
         )
         if score is None:
@@ -488,7 +488,6 @@ def _run_qiskit_action_once(
     input_qubit_count: int | None,
 ) -> tuple[QuantumCircuit, TranspileLayout | None]:
     """Run one Qiskit action attempt and update its layout metadata."""
-    # Build the concrete Qiskit pass list for a single attempt.
     if action.name == "QiskitO3" and isinstance(action, DeferredDeviceAction):
         factory = cast("Callable[[list[str], CouplingMap | None], list[Task]]", action.transpile_pass)
         passes = factory(device.operation_names, CouplingMap(device.build_coupling_map()) if layout else None)

--- a/src/mqt/predictor/rl/actions/qiskit_actions.py
+++ b/src/mqt/predictor/rl/actions/qiskit_actions.py
@@ -10,8 +10,8 @@
 
 from __future__ import annotations
 
-from copy import deepcopy
 import logging
+from copy import deepcopy
 from typing import TYPE_CHECKING, cast
 
 from qiskit.circuit import StandardEquivalenceLibrary

--- a/src/mqt/predictor/rl/actions/qiskit_actions.py
+++ b/src/mqt/predictor/rl/actions/qiskit_actions.py
@@ -10,6 +10,7 @@
 
 from __future__ import annotations
 
+from copy import deepcopy
 import logging
 from typing import TYPE_CHECKING, cast
 
@@ -358,6 +359,7 @@ def qiskit_mapping_action() -> Action:
         "QiskitSabreMapping",
         CompilationOrigin.QISKIT,
         PassType.MAPPING,
+        stochastic=True,
         transpile_pass=lambda device: cast(
             "list[Task]", [SabreLayout(coupling_map=CouplingMap(device.build_coupling_map()), skip_routing=False)]
         ),
@@ -442,9 +444,51 @@ def run_qiskit_action(
     device: Target,
     layout: TranspileLayout | None,
     input_qubit_count: int | None = None,
+    stochastic_action_trials: int = 1,
+    score: Callable[[QuantumCircuit], float] | None = None,
 ) -> tuple[QuantumCircuit, TranspileLayout | None]:
-    """Apply a Qiskit action and return the updated circuit and layout metadata."""
-    # Build the concrete Qiskit pass list for given action.
+    """Apply a Qiskit action and return the updated circuit and layout metadata.
+
+    Stochastic actions are evaluated repeatedly when a score function is
+    supplied. The highest-scoring result is retained together with its layout.
+    """
+    attempts = stochastic_action_trials if action.stochastic and score is not None else 1
+    best_result: tuple[QuantumCircuit, TranspileLayout | None] | None = None
+    best_score: float | None = None
+
+    for _ in range(max(1, attempts)):
+        altered_qc, candidate_layout = _run_qiskit_action_once(
+            action,
+            circuit,
+            device,
+            deepcopy(layout),
+            input_qubit_count,
+        )
+        if score is None:
+            return altered_qc, candidate_layout
+
+        try:
+            candidate_score = score(altered_qc)
+        except Exception:  # ruff:ignore[blind-except]
+            logger.warning("Could not evaluate stochastic action %s; using swap count instead.", action.name)
+            candidate_score = -float(altered_qc.count_ops().get("swap", 0))
+        if best_score is None or candidate_score > best_score:
+            best_result = altered_qc, candidate_layout
+            best_score = candidate_score
+
+    assert best_result is not None
+    return best_result
+
+
+def _run_qiskit_action_once(
+    action: Action,
+    circuit: QuantumCircuit,
+    device: Target,
+    layout: TranspileLayout | None,
+    input_qubit_count: int | None,
+) -> tuple[QuantumCircuit, TranspileLayout | None]:
+    """Run one Qiskit action attempt and update its layout metadata."""
+    # Build the concrete Qiskit pass list for a single attempt.
     if action.name == "QiskitO3" and isinstance(action, DeferredDeviceAction):
         factory = cast("Callable[[list[str], CouplingMap | None], list[Task]]", action.transpile_pass)
         passes = factory(device.operation_names, CouplingMap(device.build_coupling_map()) if layout else None)

--- a/src/mqt/predictor/rl/actions/qiskit_actions.py
+++ b/src/mqt/predictor/rl/actions/qiskit_actions.py
@@ -54,6 +54,7 @@ from qiskit.transpiler.passes import (
     OptimizeCliffords,
     RemoveDiagonalGatesBeforeMeasure,
     SabreLayout,
+    SabreSwap,
     Size,
     UnitarySynthesis,
     VF2Layout,
@@ -249,6 +250,20 @@ def qiskit_layout_actions() -> list[Action]:
                 ],
             ),
         ),
+    ]
+
+
+def qiskit_routing_actions() -> list[Action]:
+    """Return the Qiskit routing actions."""
+    return [
+        DeferredDeviceAction(
+            "SabreSwap",
+            CompilationOrigin.QISKIT,
+            PassType.ROUTING,
+            transpile_pass=lambda device: cast(
+                "list[Task]", [SabreSwap(coupling_map=CouplingMap(device.build_coupling_map()), heuristic="decay")]
+            ),
+        )
     ]
 
 

--- a/src/mqt/predictor/rl/actions/qiskit_actions.py
+++ b/src/mqt/predictor/rl/actions/qiskit_actions.py
@@ -50,7 +50,6 @@ from qiskit.transpiler.passes import (
     EnlargeWithAncilla,
     FixedPoint,
     FullAncillaAllocation,
-    GateDirection,
     GatesInBasis,
     InverseCancellation,
     LookaheadSwap,
@@ -350,15 +349,6 @@ def qiskit_routing_actions() -> list[Action]:
                 ],
             ),
         ),
-        DeferredDeviceAction(
-            "GateDirection",
-            CompilationOrigin.QISKIT,
-            PassType.ROUTING,
-            transpile_pass=lambda device: cast(
-                "list[Task]",
-                [GateDirection(coupling_map=CouplingMap(device.build_coupling_map()), target=device)],
-            ),
-        ),
     ]
 
 
@@ -486,15 +476,7 @@ def run_qiskit_action(
     return altered_qc, layout
 
 
-def is_qiskit_action_available(action: Action, circuit: QuantumCircuit, device: Target) -> bool:
+def is_qiskit_action_available(action: Action, device: Target) -> bool:
     """Return whether a Qiskit action is available for the current device."""
-    if action.name == "GateDirection":
-        undirected_edges = {frozenset(edge) for edge in device.build_coupling_map().get_edges()}
-        return all(
-            frozenset(circuit.find_bit(qubit).index for qubit in instruction.qubits) in undirected_edges
-            for instruction in circuit.data
-            if len(instruction.qubits) == 2
-        )
-
     # Only allow VF2PostLayout if "ibm" is in the device name # TODO: Why?
     return action.name != "VF2PostLayout" or "ibm" in device.description

--- a/src/mqt/predictor/rl/actions/qiskit_actions.py
+++ b/src/mqt/predictor/rl/actions/qiskit_actions.py
@@ -452,18 +452,25 @@ def run_qiskit_action(
     Stochastic actions are evaluated repeatedly when a score function is
     supplied. The highest-scoring result is retained together with its layout.
     """
-    attempts = stochastic_action_trials if action.stochastic and score is not None else 1
+    stochastic_run = action.stochastic and score is not None
+    attempts = stochastic_action_trials if stochastic_run else 1
     best_result: tuple[QuantumCircuit, TranspileLayout | None] | None = None
     best_score: float | None = None
 
-    for _ in range(max(1, attempts)):
-        altered_qc, candidate_layout = _run_qiskit_action_once(
-            action,
-            circuit,
-            device,
-            deepcopy(layout) if attempts > 1 else layout,
-            input_qubit_count,
-        )
+    for attempt in range(max(1, attempts)):
+        try:
+            altered_qc, candidate_layout = _run_qiskit_action_once(
+                action,
+                circuit,
+                device,
+                deepcopy(layout) if stochastic_run else layout,
+                input_qubit_count,
+            )
+        except Exception:
+            if not stochastic_run:
+                raise
+            logger.exception("Stochastic action %s failed on attempt %d.", action.name, attempt + 1)
+            continue
         if score is None:
             return altered_qc, candidate_layout
 
@@ -476,8 +483,10 @@ def run_qiskit_action(
             best_result = altered_qc, candidate_layout
             best_score = candidate_score
 
-    assert best_result is not None
-    return best_result
+    if best_result is not None:
+        return best_result
+    logger.error("All attempts for stochastic action %s failed.", action.name)
+    return circuit, layout
 
 
 def _run_qiskit_action_once(

--- a/src/mqt/predictor/rl/actions/qiskit_actions.py
+++ b/src/mqt/predictor/rl/actions/qiskit_actions.py
@@ -37,25 +37,33 @@ from qiskit.passmanager.flow_controllers import DoWhileController
 from qiskit.transpiler import CouplingMap, PassManager, TranspileLayout
 from qiskit.transpiler.passes import (
     ApplyLayout,
+    BasicSwap,
     BasisTranslator,
     Collect2qBlocks,
+    CollectCliffords,
     CommutativeCancellation,
     CommutativeInverseCancellation,
     ConsolidateBlocks,
     DenseLayout,
     Depth,
+    ElidePermutations,
     EnlargeWithAncilla,
     FixedPoint,
     FullAncillaAllocation,
+    GateDirection,
     GatesInBasis,
     InverseCancellation,
+    LookaheadSwap,
     MinimumPoint,
     Optimize1qGatesDecomposition,
+    Optimize1qGatesSimpleCommutation,
     OptimizeCliffords,
     RemoveDiagonalGatesBeforeMeasure,
+    RemoveIdentityEquivalent,
     SabreLayout,
     SabreSwap,
     Size,
+    TrivialLayout,
     UnitarySynthesis,
     VF2Layout,
     VF2PostLayout,
@@ -150,7 +158,7 @@ def qiskit_optimization_actions() -> list[Action]:
             "OptimizeCliffords",
             CompilationOrigin.QISKIT,
             PassType.OPT,
-            [OptimizeCliffords()],
+            [CollectCliffords(), OptimizeCliffords()],
             preserves_layout=True,
             preserves_routing=False,
             preserves_synthesis=False,
@@ -163,6 +171,32 @@ def qiskit_optimization_actions() -> list[Action]:
             preserves_layout=True,
             preserves_routing=True,
             preserves_synthesis=False,
+        ),
+        DeviceIndependentAction(
+            "RemoveIdentityEquivalent",
+            CompilationOrigin.QISKIT,
+            PassType.OPT,
+            [RemoveIdentityEquivalent()],
+            preserves_layout=True,
+            preserves_routing=True,
+            preserves_synthesis=True,
+        ),
+        DeferredDeviceAction(
+            "Optimize1qGatesSimpleCommutation",
+            CompilationOrigin.QISKIT,
+            PassType.OPT,
+            transpile_pass=lambda device: cast(
+                "list[Task]",
+                [
+                    Optimize1qGatesSimpleCommutation(
+                        basis=device.operation_names,
+                        run_to_completion=True,
+                    )
+                ],
+            ),
+            preserves_layout=True,
+            preserves_routing=True,
+            preserves_synthesis=True,
         ),
     ]
 
@@ -250,6 +284,35 @@ def qiskit_layout_actions() -> list[Action]:
                 ],
             ),
         ),
+        DeferredDeviceAction(
+            "TrivialLayout",
+            CompilationOrigin.QISKIT,
+            PassType.LAYOUT,
+            transpile_pass=lambda device: cast(
+                "list[Task]",
+                [
+                    TrivialLayout(coupling_map=CouplingMap(device.build_coupling_map())),
+                    FullAncillaAllocation(coupling_map=CouplingMap(device.build_coupling_map())),
+                    EnlargeWithAncilla(),
+                    ApplyLayout(),
+                ],
+            ),
+        ),
+        DeferredDeviceAction(
+            "ElidePermutations",
+            CompilationOrigin.QISKIT,
+            PassType.LAYOUT,
+            transpile_pass=lambda device: cast(
+                "list[Task]",
+                [
+                    ElidePermutations(),
+                    TrivialLayout(coupling_map=CouplingMap(device.build_coupling_map())),
+                    FullAncillaAllocation(coupling_map=CouplingMap(device.build_coupling_map())),
+                    EnlargeWithAncilla(),
+                    ApplyLayout(),
+                ],
+            ),
+        ),
     ]
 
 
@@ -263,7 +326,39 @@ def qiskit_routing_actions() -> list[Action]:
             transpile_pass=lambda device: cast(
                 "list[Task]", [SabreSwap(coupling_map=CouplingMap(device.build_coupling_map()), heuristic="decay")]
             ),
-        )
+        ),
+        DeferredDeviceAction(
+            "BasicSwap",
+            CompilationOrigin.QISKIT,
+            PassType.ROUTING,
+            transpile_pass=lambda device: cast(
+                "list[Task]", [BasicSwap(coupling_map=CouplingMap(device.build_coupling_map()))]
+            ),
+        ),
+        DeferredDeviceAction(
+            "LookaheadSwap",
+            CompilationOrigin.QISKIT,
+            PassType.ROUTING,
+            transpile_pass=lambda device: cast(
+                "list[Task]",
+                [
+                    LookaheadSwap(
+                        coupling_map=CouplingMap(device.build_coupling_map()),
+                        search_depth=1,
+                        search_width=1,
+                    )
+                ],
+            ),
+        ),
+        DeferredDeviceAction(
+            "GateDirection",
+            CompilationOrigin.QISKIT,
+            PassType.ROUTING,
+            transpile_pass=lambda device: cast(
+                "list[Task]",
+                [GateDirection(coupling_map=CouplingMap(device.build_coupling_map()), target=device)],
+            ),
+        ),
     ]
 
 
@@ -385,11 +480,21 @@ def run_qiskit_action(
     if altered_qc.count_ops().get("unitary"):
         # Custom "unitary" gates can not be processed further by other passes
         altered_qc = altered_qc.decompose(gates_to_decompose="unitary")
+    if altered_qc.count_ops().get("clifford"):
+        altered_qc = altered_qc.decompose(gates_to_decompose="clifford")
 
     return altered_qc, layout
 
 
-def is_qiskit_action_available(action: Action, device: Target) -> bool:
+def is_qiskit_action_available(action: Action, circuit: QuantumCircuit, device: Target) -> bool:
     """Return whether a Qiskit action is available for the current device."""
+    if action.name == "GateDirection":
+        undirected_edges = {frozenset(edge) for edge in device.build_coupling_map().get_edges()}
+        return all(
+            frozenset(circuit.find_bit(qubit).index for qubit in instruction.qubits) in undirected_edges
+            for instruction in circuit.data
+            if len(instruction.qubits) == 2
+        )
+
     # Only allow VF2PostLayout if "ibm" is in the device name # TODO: Why?
     return action.name != "VF2PostLayout" or "ibm" in device.description

--- a/src/mqt/predictor/rl/actions/qiskit_actions.py
+++ b/src/mqt/predictor/rl/actions/qiskit_actions.py
@@ -323,6 +323,7 @@ def qiskit_routing_actions() -> list[Action]:
             "SabreSwap",
             CompilationOrigin.QISKIT,
             PassType.ROUTING,
+            stochastic=True,
             transpile_pass=lambda device: cast(
                 "list[Task]", [SabreSwap(coupling_map=CouplingMap(device.build_coupling_map()), heuristic="decay")]
             ),

--- a/src/mqt/predictor/rl/actions/qiskit_actions.py
+++ b/src/mqt/predictor/rl/actions/qiskit_actions.py
@@ -467,6 +467,8 @@ def run_qiskit_action(
                 deepcopy(layout) if stochastic_run else layout,
                 input_qubit_count,
             )
+        except TimeoutError:
+            raise
         except Exception:
             if not stochastic_run:
                 raise
@@ -477,6 +479,8 @@ def run_qiskit_action(
 
         try:
             candidate_score = score(altered_qc)
+        except TimeoutError:
+            raise
         except Exception:  # ruff:ignore[blind-except]
             logger.warning("Could not evaluate stochastic action %s; using swap count instead.", action.name)
             candidate_score = -float(altered_qc.count_ops().get("swap", 0))

--- a/src/mqt/predictor/rl/actions/registry.py
+++ b/src/mqt/predictor/rl/actions/registry.py
@@ -51,6 +51,7 @@ def get_actions_by_pass_type() -> dict[PassType, list[Action]]:
 
 for _action in (
     *qiskit_actions.qiskit_layout_actions(),
+    *qiskit_actions.qiskit_routing_actions(),
     qiskit_actions.qiskit_mapping_action(),
     qiskit_actions.qiskit_synthesis_action(),
     qiskit_actions.qiskit_o3_action(),

--- a/src/mqt/predictor/rl/helper.py
+++ b/src/mqt/predictor/rl/helper.py
@@ -11,6 +11,7 @@
 from __future__ import annotations
 
 import logging
+from math import log1p
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -28,6 +29,7 @@ from importlib import resources
 
 logger = logging.getLogger("mqt-predictor")
 
+MAX_CIRCUIT_DEPTH = 999_999
 OBSERVATION_OPERATIONS = tuple(get_openqasm_gates())
 
 
@@ -72,11 +74,13 @@ def get_state_sample(max_qubits: int, path_training_circuits: Path, rng: Generat
     return qc, str(file_list[random_index])
 
 
-def create_feature_dict(qc: QuantumCircuit) -> dict[str, int | NDArray[np.float32]]:
+def create_feature_dict(qc: QuantumCircuit, max_num_qubits: int) -> dict[str, NDArray[np.float32]]:
     """Create a normalized feature dictionary for a quantum circuit."""
     operation_counts = dict(qc.count_ops())
     total_operations = sum(value for gate, value in operation_counts.items() if gate != "barrier")
-    feature_dict: dict[str, int | NDArray[np.float32]] = {
+    normalized_num_qubits = min(qc.num_qubits, max_num_qubits) / max_num_qubits
+    normalized_depth = log1p(min(qc.depth(), MAX_CIRCUIT_DEPTH)) / log1p(MAX_CIRCUIT_DEPTH)
+    feature_dict = {
         **{
             operation: np.array(
                 [operation_counts.get(operation, 0) / total_operations if total_operations else 0.0],
@@ -84,8 +88,8 @@ def create_feature_dict(qc: QuantumCircuit) -> dict[str, int | NDArray[np.float3
             )
             for operation in OBSERVATION_OPERATIONS
         },
-        "num_qubits": qc.num_qubits,
-        "depth": qc.depth(),
+        "num_qubits": np.array([normalized_num_qubits], dtype=np.float32),
+        "depth": np.array([normalized_depth], dtype=np.float32),
     }
 
     supermarq_features = calc_supermarq_features(qc)

--- a/src/mqt/predictor/rl/predictorenv.py
+++ b/src/mqt/predictor/rl/predictorenv.py
@@ -71,6 +71,7 @@ class PredictorEnv(Env):
         max_steps: int | None = None,
         tracer_output_path: str | Path | None = None,
         mdp: MDPPolicy = "v3",
+        stochastic_action_trials: int = 20,
     ) -> None:
         """Initializes the PredictorEnv object.
 
@@ -83,6 +84,8 @@ class PredictorEnv(Env):
             mdp: The MDP transition policy. ``v2`` is the original MQT Predictor
                 strategy. ``v3`` is the default and is permissive before layout while
                 preserving the established compilation structure afterwards.
+            stochastic_action_trials: Number of attempts used to select the best
+                result from a stochastic action.
 
         Raises:
             ValueError: If ``mdp`` is unsupported, if the reward function is
@@ -96,10 +99,14 @@ class PredictorEnv(Env):
         if mdp not in MDP_POLICIES:
             msg = f"Unsupported MDP policy: {mdp}."
             raise ValueError(msg)
+        if stochastic_action_trials < 1:
+            msg = "stochastic_action_trials must be at least one."
+            raise ValueError(msg)
 
         self.path_training_circuits = path_training_circuits or get_path_training_circuits()
         self.max_steps = max_steps
         self.mdp = mdp
+        self.stochastic_action_trials = stochastic_action_trials
 
         self.action_set = {}
         self.actions_synthesis_indices = []
@@ -549,6 +556,8 @@ class PredictorEnv(Env):
                 device=self.device,
                 layout=self.layout,
                 input_qubit_count=self.num_qubits_uncompiled_circuit,
+                stochastic_action_trials=self.stochastic_action_trials,
+                score=self._score_circuit if action.stochastic else None,
             )
         elif action.origin == CompilationOrigin.TKET:
             altered_qc, self.layout = run_tket_action(
@@ -569,6 +578,19 @@ class PredictorEnv(Env):
             raise ValueError(msg)
 
         return altered_qc
+
+    def _score_circuit(self, circuit: QuantumCircuit) -> float:
+        """Calculate the configured figure of merit for an action candidate."""
+        if self.reward_function == "expected_fidelity":
+            return expected_fidelity(circuit, self.device)
+        if self.reward_function == "estimated_success_probability":
+            return estimated_success_probability(circuit, self.device)
+        if self.reward_function == "estimated_hellinger_distance":
+            return estimated_hellinger_distance(circuit, self.device, self.hellinger_model)
+        if self.reward_function == "critical_depth":
+            return crit_depth(circuit)
+        msg = f"No implementation for reward function {self.reward_function}."
+        raise NotImplementedError(msg)
 
     def is_circuit_laid_out(self, circuit: QuantumCircuit, layout: TranspileLayout | Layout) -> bool:
         """True if every logical qubit in the circuit has a physical assignment."""

--- a/src/mqt/predictor/rl/predictorenv.py
+++ b/src/mqt/predictor/rl/predictorenv.py
@@ -28,7 +28,9 @@ from gymnasium import Env
 from gymnasium.spaces import Box, Dict, Discrete
 from joblib import load
 from qiskit import QuantumCircuit
-from qiskit.transpiler import CouplingMap, TranspileLayout
+from qiskit.circuit import StandardEquivalenceLibrary
+from qiskit.transpiler import CouplingMap, PassManager, TranspileLayout
+from qiskit.transpiler.passes import BasisTranslator
 
 from mqt.predictor.hellinger import get_hellinger_model_path
 from mqt.predictor.reward import (
@@ -581,14 +583,17 @@ class PredictorEnv(Env):
 
     def _score_circuit(self, circuit: QuantumCircuit) -> float:
         """Calculate the configured figure of merit for an action candidate."""
+        scoring_circuit = PassManager(
+            [BasisTranslator(StandardEquivalenceLibrary, target_basis=self.device.operation_names)]
+        ).run(circuit.copy())
         if self.reward_function == "expected_fidelity":
-            return expected_fidelity(circuit, self.device)
+            return expected_fidelity(scoring_circuit, self.device)
         if self.reward_function == "estimated_success_probability":
-            return estimated_success_probability(circuit, self.device)
+            return estimated_success_probability(scoring_circuit, self.device)
         if self.reward_function == "estimated_hellinger_distance":
-            return estimated_hellinger_distance(circuit, self.device, self.hellinger_model)
+            return estimated_hellinger_distance(scoring_circuit, self.device, self.hellinger_model)
         if self.reward_function == "critical_depth":
-            return crit_depth(circuit)
+            return crit_depth(scoring_circuit)
         msg = f"No implementation for reward function {self.reward_function}."
         raise NotImplementedError(msg)
 

--- a/src/mqt/predictor/rl/predictorenv.py
+++ b/src/mqt/predictor/rl/predictorenv.py
@@ -583,9 +583,9 @@ class PredictorEnv(Env):
 
     def _score_circuit(self, circuit: QuantumCircuit) -> float:
         """Calculate the configured figure of merit for an action candidate."""
-        scoring_circuit = PassManager(
-            [BasisTranslator(StandardEquivalenceLibrary, target_basis=self.device.operation_names)]
-        ).run(circuit.copy())
+        scoring_circuit = PassManager([
+            BasisTranslator(StandardEquivalenceLibrary, target_basis=self.device.operation_names)
+        ]).run(circuit.copy())
         if self.reward_function == "expected_fidelity":
             return expected_fidelity(scoring_circuit, self.device)
         if self.reward_function == "estimated_success_probability":

--- a/src/mqt/predictor/rl/predictorenv.py
+++ b/src/mqt/predictor/rl/predictorenv.py
@@ -506,7 +506,7 @@ class PredictorEnv(Env):
                 action_mask.append(True)
                 continue
             if action.origin == CompilationOrigin.QISKIT:
-                action_mask.append(is_qiskit_action_available(action, self.state, self.device))
+                action_mask.append(is_qiskit_action_available(action, self.device))
             elif action.origin == CompilationOrigin.TKET:
                 action_mask.append(is_tket_action_available(action=action, has_layout=has_layout))
             elif action.origin == CompilationOrigin.BQSKIT:

--- a/src/mqt/predictor/rl/predictorenv.py
+++ b/src/mqt/predictor/rl/predictorenv.py
@@ -183,8 +183,8 @@ class PredictorEnv(Env):
             operation: Box(low=0, high=1, shape=(1,), dtype=np.float32) for operation in OBSERVATION_OPERATIONS
         }
         spaces: dict[str, Space] = {
-            "num_qubits": Discrete(128),
-            "depth": Discrete(1000000),
+            "num_qubits": Box(low=0, high=1, shape=(1,), dtype=np.float32),
+            "depth": Box(low=0, high=1, shape=(1,), dtype=np.float32),
             **operation_spaces,
             "program_communication": Box(low=0, high=1, shape=(1,), dtype=np.float32),
             "critical_depth": Box(low=0, high=1, shape=(1,), dtype=np.float32),
@@ -297,7 +297,7 @@ class PredictorEnv(Env):
             action_duration = time.perf_counter() - start_time
             # Different passes may fail for various reasons (e.g., found no routing solution).
             self.error_occurred = True
-            obs = create_feature_dict(self.state)
+            obs = create_feature_dict(self.state, self.device.num_qubits)
 
             # Trace the error before aborting
             self._collect_tracer_data(
@@ -337,7 +337,7 @@ class PredictorEnv(Env):
             reward_val = 0
             done = False
 
-        obs = create_feature_dict(self.state)
+        obs = create_feature_dict(self.state, self.device.num_qubits)
 
         # Trace+truncate if step limit is reached
         if not done and self.max_steps is not None and self.num_steps >= self.max_steps:
@@ -447,7 +447,7 @@ class PredictorEnv(Env):
         self.num_qubits_uncompiled_circuit = self.state.num_qubits
         self.has_parameterized_gates = len(self.state.parameters) > 0
 
-        obs = create_feature_dict(self.state)
+        obs = create_feature_dict(self.state, self.device.num_qubits)
 
         # Setup tracer for the new episode
         if self.tracer_output_path is not None:

--- a/src/mqt/predictor/rl/predictorenv.py
+++ b/src/mqt/predictor/rl/predictorenv.py
@@ -506,7 +506,7 @@ class PredictorEnv(Env):
                 action_mask.append(True)
                 continue
             if action.origin == CompilationOrigin.QISKIT:
-                action_mask.append(is_qiskit_action_available(action, self.device))
+                action_mask.append(is_qiskit_action_available(action, self.state, self.device))
             elif action.origin == CompilationOrigin.TKET:
                 action_mask.append(is_tket_action_available(action=action, has_layout=has_layout))
             elif action.origin == CompilationOrigin.BQSKIT:

--- a/src/mqt/predictor/rl/tracer.py
+++ b/src/mqt/predictor/rl/tracer.py
@@ -209,7 +209,7 @@ class CompilationTracer:
         reward: float,
         current_qc: QuantumCircuit,
         figures_of_merit: FigureOfMeritMetrics,
-        features: dict[str, int | NDArray[np.float32]],
+        features: dict[str, NDArray[np.float32]],
         synthesized: bool,
         laid_out: bool,
         routed: bool,
@@ -337,8 +337,6 @@ class CompilationTracer:
         )
 
     @staticmethod
-    def _extract_float(val: int | NDArray[np.float32]) -> float:
-        """Extract a float from a scalar or one-element feature array."""
-        if isinstance(val, int):
-            return float(val)
+    def _extract_float(val: NDArray[np.float32]) -> float:
+        """Extract a float from a one-element feature array."""
         return float(val.item())

--- a/tests/compilation/test_helper_rl.py
+++ b/tests/compilation/test_helper_rl.py
@@ -45,22 +45,20 @@ def test_create_feature_dict() -> None:
     qc.ccx(0, 1, 2)
     qc.measure_all()
 
-    features = create_feature_dict(qc)
+    max_num_qubits = 20
+    features = create_feature_dict(qc, max_num_qubits)
 
-    for name, feature in features.items():
-        if name in {"num_qubits", "depth"}:
-            assert isinstance(feature, int)
-        else:
-            assert isinstance(feature, np.ndarray)
-            assert feature.dtype == np.float32
+    for feature in features.values():
+        assert isinstance(feature, np.ndarray)
+        assert feature.dtype == np.float32
 
     np.testing.assert_allclose(features["h"], [1 / 6])
     np.testing.assert_allclose(features["cx"], [1 / 6])
     np.testing.assert_allclose(features["ccx"], [1 / 6])
     np.testing.assert_allclose(features["measure"], [0.5])
     np.testing.assert_allclose(features["x"], [0])
-    assert features["num_qubits"] == qc.num_qubits
-    assert features["depth"] == qc.depth()
+    np.testing.assert_allclose(features["num_qubits"], [3 / max_num_qubits])
+    np.testing.assert_allclose(features["depth"], [np.log1p(qc.depth()) / np.log1p(999_999)])
 
 
 def test_get_path_trained_model() -> None:

--- a/tests/compilation/test_integration_further_SDKs.py
+++ b/tests/compilation/test_integration_further_SDKs.py
@@ -10,13 +10,12 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
-
 import pytest
 from mqt.bench.targets import get_device
 from qiskit import QuantumCircuit
 from qiskit.circuit import StandardEquivalenceLibrary
-from qiskit.transpiler import PassManager, TranspileLayout
+from qiskit.circuit.library import CXGate, HGate
+from qiskit.transpiler import PassManager, Target, TranspileLayout
 from qiskit.transpiler.passes import (
     ApplyLayout,
     BasisTranslator,
@@ -28,9 +27,6 @@ from qiskit.transpiler.passes import (
 
 from mqt.predictor.rl.actions import CompilationOrigin, PassType
 from mqt.predictor.rl.predictorenv import PredictorEnv
-
-if TYPE_CHECKING:
-    from qiskit.transpiler import Target
 
 
 def _setup_env(env: PredictorEnv, circuit: QuantumCircuit, layout: TranspileLayout | None, n_qubits: int) -> None:
@@ -126,6 +122,16 @@ def env(target: Target) -> PredictorEnv:
     return PredictorEnv(device=target, reward_function="expected_fidelity")
 
 
+@pytest.fixture
+def directional_env() -> PredictorEnv:
+    """Create an environment for direction-sensitive routing actions."""
+    target = Target(num_qubits=2, description="directional test target")
+    target.add_instruction(HGate(), {(0,): None, (1,): None})
+    target.add_instruction(CXGate(), {(0, 1): None})
+    with pytest.warns(UserWarning, match="uni-directional"):
+        return PredictorEnv(device=target, reward_function="expected_fidelity")
+
+
 def test_synthesis_actions_produce_native_gates(
     simple_circuit: QuantumCircuit,
     env: PredictorEnv,
@@ -169,12 +175,7 @@ def test_layout_actions_establish_layout(
     for idx, action in env.action_set.items():
         if action.pass_type != PassType.LAYOUT:
             continue
-        circuit = synthesized
-        if action.name == "ElidePermutations":
-            circuit = QuantumCircuit(3)
-            circuit.swap(0, 1)
-            circuit.x(0)
-        _setup_env(env, circuit, None, circuit.num_qubits)
+        _setup_env(env, synthesized, None, synthesized.num_qubits)
         if not _is_available(env, idx):
             continue
         compiled = env.apply_action(idx)
@@ -186,9 +187,6 @@ def test_layout_actions_establish_layout(
             f"{action.name} on {env.device.description} VIOLATED INVARIANT: "
             f"did not establish valid layout. Layout: {env.layout}"
         )
-        if action.name == "ElidePermutations":
-            assert "swap" not in compiled.count_ops()
-            assert env.layout.final_index_layout() == [1, 0, 2]
 
     assert applied_actions > 0
 
@@ -229,38 +227,48 @@ def test_mapping_actions_establish_layout_and_route(
 def test_routing_actions_route_circuit(
     simple_circuit: QuantumCircuit,
     env: PredictorEnv,
+    directional_env: PredictorEnv,
 ) -> None:
     """Invariant: every routing action produces a circuit where all 2-qubit gates respect the coupling map."""
-    coupling_map = env.device.build_coupling_map()
-    applied_actions = 0
-
     for idx, action in env.action_set.items():
         if action.pass_type != PassType.ROUTING:
             continue
+
         qc_laid_out, layout = _lay_out(simple_circuit, env.device)
-        n_qubits = qc_laid_out.num_qubits
-        _setup_env(env, qc_laid_out, layout, n_qubits)
-        if not _is_available(env, idx):
-            continue
-        routed = env.apply_action(idx)
-        applied_actions += 1
-        assert env.is_circuit_routed(routed, coupling_map), (
-            f"{action.name} on {env.device.description} VIOLATED INVARIANT: circuit not properly routed after action"
+        directional_circuit = QuantumCircuit(2)
+        directional_circuit.cx(1, 0)
+        directional_laid_out, directional_layout = _lay_out(directional_circuit, directional_env.device)
+        test_cases = (
+            (env, qc_laid_out, layout),
+            (directional_env, directional_laid_out, directional_layout),
+        )
+
+        for action_env, circuit, action_layout in test_cases:
+            n_qubits = circuit.num_qubits
+            _setup_env(action_env, circuit, action_layout, n_qubits)
+            if _is_available(action_env, idx):
+                routed = action_env.apply_action(idx)
+                break
+        else:
+            pytest.fail(f"{action.name} was unavailable for all routing test cases")
+
+        coupling_map = action_env.device.build_coupling_map()
+        assert action_env.is_circuit_routed(routed, coupling_map), (
+            f"{action.name} on {action_env.device.description} VIOLATED INVARIANT: "
+            "circuit not properly routed after action"
         )
         # Check BQSKit routing translates its output permutation into Qiskit layout bookkeeping correctly.
         if action.origin == CompilationOrigin.BQSKIT:
-            assert env.layout is not None
-            assert env.layout.final_layout is not None
-            assert set(env.layout.final_layout.get_virtual_bits()).issubset(routed.qubits)
-            assert env.layout._output_qubit_list == routed.qubits  # ruff: ignore[private-member-access]
+            assert action_env.layout is not None
+            assert action_env.layout.final_layout is not None
+            assert set(action_env.layout.final_layout.get_virtual_bits()).issubset(routed.qubits)
+            assert action_env.layout._output_qubit_list == routed.qubits  # ruff: ignore[private-member-access]
 
-            _setup_env(env, routed, env.layout, n_qubits)
-            rerouted = env.apply_action(idx)
-            assert env.layout.final_layout is not None
-            assert set(env.layout.final_layout.get_virtual_bits()).issubset(rerouted.qubits)
-            assert env.layout._output_qubit_list == rerouted.qubits  # ruff: ignore[private-member-access]
-
-    assert applied_actions > 0
+            _setup_env(action_env, routed, action_env.layout, n_qubits)
+            rerouted = action_env.apply_action(idx)
+            assert action_env.layout.final_layout is not None
+            assert set(action_env.layout.final_layout.get_virtual_bits()).issubset(rerouted.qubits)
+            assert action_env.layout._output_qubit_list == rerouted.qubits  # ruff: ignore[private-member-access]
 
 
 def test_optimization_actions_preserve_invariants(
@@ -316,10 +324,3 @@ def test_optimization_actions_preserve_invariants(
                     f"Device native gates: {env.device.operation_names}. "
                     f"Circuit gates: {set(compiled.count_ops().keys())}"
                 )
-
-        if action.name == "OptimizeCliffords":
-            clifford_circuit = QuantumCircuit(1)
-            clifford_circuit.h(0)
-            clifford_circuit.h(0)
-            _setup_env(env, clifford_circuit, None, clifford_circuit.num_qubits)
-            assert not env.apply_action(idx).data

--- a/tests/compilation/test_integration_further_SDKs.py
+++ b/tests/compilation/test_integration_further_SDKs.py
@@ -10,13 +10,12 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
-
 import pytest
 from mqt.bench.targets import get_device
 from qiskit import QuantumCircuit
 from qiskit.circuit import StandardEquivalenceLibrary
-from qiskit.transpiler import PassManager, TranspileLayout
+from qiskit.circuit.library import CXGate, HGate
+from qiskit.transpiler import PassManager, Target, TranspileLayout
 from qiskit.transpiler.passes import (
     ApplyLayout,
     BasisTranslator,
@@ -28,9 +27,6 @@ from qiskit.transpiler.passes import (
 
 from mqt.predictor.rl.actions import CompilationOrigin, PassType
 from mqt.predictor.rl.predictorenv import PredictorEnv
-
-if TYPE_CHECKING:
-    from qiskit.transpiler import Target
 
 
 def _setup_env(env: PredictorEnv, circuit: QuantumCircuit, layout: TranspileLayout | None, n_qubits: int) -> None:
@@ -44,6 +40,11 @@ def _is_available(env: PredictorEnv, idx: int) -> bool:
     """Return whether action idx is structurally and SDK-valid for the current env state."""
     env.valid_actions = env.determine_valid_actions_for_state()
     return env.action_masks()[idx]
+
+
+def _action_index(env: PredictorEnv, name: str) -> int:
+    """Return the index of an action with the given name."""
+    return next(idx for idx, action in env.action_set.items() if action.name == name)
 
 
 def _lay_out(circuit: QuantumCircuit, target: Target) -> tuple[QuantumCircuit, TranspileLayout]:
@@ -124,6 +125,69 @@ def simple_circuit() -> QuantumCircuit:
 def env(target: Target) -> PredictorEnv:
     """Create a PredictorEnv for state-based invariant checking."""
     return PredictorEnv(device=target, reward_function="expected_fidelity")
+
+
+def test_requested_qiskit_passes_are_registered(env: PredictorEnv) -> None:
+    """All requested individual Qiskit passes are exposed as RL actions."""
+    action_names = {action.name for action in env.action_set.values()}
+    assert {
+        "BasicSwap",
+        "ElidePermutations",
+        "GateDirection",
+        "LookaheadSwap",
+        "Optimize1qGatesSimpleCommutation",
+        "RemoveIdentityEquivalent",
+        "TrivialLayout",
+    } <= action_names
+
+
+def test_elide_permutations_tracks_output_permutation(env: PredictorEnv) -> None:
+    """Eliding a SWAP keeps its output permutation in the established layout."""
+    circuit = QuantumCircuit(3)
+    circuit.swap(0, 1)
+    circuit.x(0)
+    _setup_env(env, circuit, None, circuit.num_qubits)
+
+    compiled = env.apply_action(_action_index(env, "ElidePermutations"))
+
+    assert "swap" not in compiled.count_ops()
+    assert [
+        (instruction.operation.name, compiled.find_bit(instruction.qubits[0]).index) for instruction in compiled.data
+    ] == [("x", 1)]
+    assert env.layout is not None
+    assert env.layout.final_index_layout() == [1, 0, 2]
+
+
+def test_gate_direction_routes_adjacent_directional_gate() -> None:
+    """GateDirection is available once only edge direction remains to be fixed."""
+    directional_target = Target(num_qubits=2, description="directional test target")
+    directional_target.add_instruction(HGate(), {(0,): None, (1,): None})
+    directional_target.add_instruction(CXGate(), {(0, 1): None})
+    with pytest.warns(UserWarning, match="uni-directional"):
+        directional_env = PredictorEnv(device=directional_target, reward_function="expected_fidelity")
+
+    circuit = QuantumCircuit(2)
+    circuit.cx(1, 0)
+    laid_out, layout = _lay_out(circuit, directional_target)
+    _setup_env(directional_env, laid_out, layout, circuit.num_qubits)
+    action_index = _action_index(directional_env, "GateDirection")
+
+    assert _is_available(directional_env, action_index)
+    compiled = directional_env.apply_action(action_index)
+
+    assert directional_env.is_circuit_routed(compiled, directional_target.build_coupling_map())
+
+
+def test_optimize_cliffords_collects_standard_clifford_gates(env: PredictorEnv) -> None:
+    """OptimizeCliffords first collects ordinary gates and decomposes its result."""
+    circuit = QuantumCircuit(1)
+    circuit.h(0)
+    circuit.h(0)
+    _setup_env(env, circuit, None, circuit.num_qubits)
+
+    compiled = env.apply_action(_action_index(env, "OptimizeCliffords"))
+
+    assert not compiled.data
 
 
 def test_synthesis_actions_produce_native_gates(

--- a/tests/compilation/test_integration_further_SDKs.py
+++ b/tests/compilation/test_integration_further_SDKs.py
@@ -10,12 +10,13 @@
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 import pytest
 from mqt.bench.targets import get_device
 from qiskit import QuantumCircuit
 from qiskit.circuit import StandardEquivalenceLibrary
-from qiskit.circuit.library import CXGate, HGate
-from qiskit.transpiler import PassManager, Target, TranspileLayout
+from qiskit.transpiler import PassManager, TranspileLayout
 from qiskit.transpiler.passes import (
     ApplyLayout,
     BasisTranslator,
@@ -27,6 +28,9 @@ from qiskit.transpiler.passes import (
 
 from mqt.predictor.rl.actions import CompilationOrigin, PassType
 from mqt.predictor.rl.predictorenv import PredictorEnv
+
+if TYPE_CHECKING:
+    from qiskit.transpiler import Target
 
 
 def _setup_env(env: PredictorEnv, circuit: QuantumCircuit, layout: TranspileLayout | None, n_qubits: int) -> None:
@@ -40,11 +44,6 @@ def _is_available(env: PredictorEnv, idx: int) -> bool:
     """Return whether action idx is structurally and SDK-valid for the current env state."""
     env.valid_actions = env.determine_valid_actions_for_state()
     return env.action_masks()[idx]
-
-
-def _action_index(env: PredictorEnv, name: str) -> int:
-    """Return the index of an action with the given name."""
-    return next(idx for idx, action in env.action_set.items() if action.name == name)
 
 
 def _lay_out(circuit: QuantumCircuit, target: Target) -> tuple[QuantumCircuit, TranspileLayout]:
@@ -127,69 +126,6 @@ def env(target: Target) -> PredictorEnv:
     return PredictorEnv(device=target, reward_function="expected_fidelity")
 
 
-def test_requested_qiskit_passes_are_registered(env: PredictorEnv) -> None:
-    """All requested individual Qiskit passes are exposed as RL actions."""
-    action_names = {action.name for action in env.action_set.values()}
-    assert {
-        "BasicSwap",
-        "ElidePermutations",
-        "GateDirection",
-        "LookaheadSwap",
-        "Optimize1qGatesSimpleCommutation",
-        "RemoveIdentityEquivalent",
-        "TrivialLayout",
-    } <= action_names
-
-
-def test_elide_permutations_tracks_output_permutation(env: PredictorEnv) -> None:
-    """Eliding a SWAP keeps its output permutation in the established layout."""
-    circuit = QuantumCircuit(3)
-    circuit.swap(0, 1)
-    circuit.x(0)
-    _setup_env(env, circuit, None, circuit.num_qubits)
-
-    compiled = env.apply_action(_action_index(env, "ElidePermutations"))
-
-    assert "swap" not in compiled.count_ops()
-    assert [
-        (instruction.operation.name, compiled.find_bit(instruction.qubits[0]).index) for instruction in compiled.data
-    ] == [("x", 1)]
-    assert env.layout is not None
-    assert env.layout.final_index_layout() == [1, 0, 2]
-
-
-def test_gate_direction_routes_adjacent_directional_gate() -> None:
-    """GateDirection is available once only edge direction remains to be fixed."""
-    directional_target = Target(num_qubits=2, description="directional test target")
-    directional_target.add_instruction(HGate(), {(0,): None, (1,): None})
-    directional_target.add_instruction(CXGate(), {(0, 1): None})
-    with pytest.warns(UserWarning, match="uni-directional"):
-        directional_env = PredictorEnv(device=directional_target, reward_function="expected_fidelity")
-
-    circuit = QuantumCircuit(2)
-    circuit.cx(1, 0)
-    laid_out, layout = _lay_out(circuit, directional_target)
-    _setup_env(directional_env, laid_out, layout, circuit.num_qubits)
-    action_index = _action_index(directional_env, "GateDirection")
-
-    assert _is_available(directional_env, action_index)
-    compiled = directional_env.apply_action(action_index)
-
-    assert directional_env.is_circuit_routed(compiled, directional_target.build_coupling_map())
-
-
-def test_optimize_cliffords_collects_standard_clifford_gates(env: PredictorEnv) -> None:
-    """OptimizeCliffords first collects ordinary gates and decomposes its result."""
-    circuit = QuantumCircuit(1)
-    circuit.h(0)
-    circuit.h(0)
-    _setup_env(env, circuit, None, circuit.num_qubits)
-
-    compiled = env.apply_action(_action_index(env, "OptimizeCliffords"))
-
-    assert not compiled.data
-
-
 def test_synthesis_actions_produce_native_gates(
     simple_circuit: QuantumCircuit,
     env: PredictorEnv,
@@ -233,7 +169,12 @@ def test_layout_actions_establish_layout(
     for idx, action in env.action_set.items():
         if action.pass_type != PassType.LAYOUT:
             continue
-        _setup_env(env, synthesized, None, synthesized.num_qubits)
+        circuit = synthesized
+        if action.name == "ElidePermutations":
+            circuit = QuantumCircuit(3)
+            circuit.swap(0, 1)
+            circuit.x(0)
+        _setup_env(env, circuit, None, circuit.num_qubits)
         if not _is_available(env, idx):
             continue
         compiled = env.apply_action(idx)
@@ -245,6 +186,9 @@ def test_layout_actions_establish_layout(
             f"{action.name} on {env.device.description} VIOLATED INVARIANT: "
             f"did not establish valid layout. Layout: {env.layout}"
         )
+        if action.name == "ElidePermutations":
+            assert "swap" not in compiled.count_ops()
+            assert env.layout.final_index_layout() == [1, 0, 2]
 
     assert applied_actions > 0
 
@@ -372,3 +316,10 @@ def test_optimization_actions_preserve_invariants(
                     f"Device native gates: {env.device.operation_names}. "
                     f"Circuit gates: {set(compiled.count_ops().keys())}"
                 )
+
+        if action.name == "OptimizeCliffords":
+            clifford_circuit = QuantumCircuit(1)
+            clifford_circuit.h(0)
+            clifford_circuit.h(0)
+            _setup_env(env, clifford_circuit, None, clifford_circuit.num_qubits)
+            assert not env.apply_action(idx).data

--- a/tests/compilation/test_integration_further_SDKs.py
+++ b/tests/compilation/test_integration_further_SDKs.py
@@ -10,12 +10,13 @@
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 import pytest
 from mqt.bench.targets import get_device
 from qiskit import QuantumCircuit
 from qiskit.circuit import StandardEquivalenceLibrary
-from qiskit.circuit.library import CXGate, HGate
-from qiskit.transpiler import PassManager, Target, TranspileLayout
+from qiskit.transpiler import PassManager, TranspileLayout
 from qiskit.transpiler.passes import (
     ApplyLayout,
     BasisTranslator,
@@ -27,6 +28,9 @@ from qiskit.transpiler.passes import (
 
 from mqt.predictor.rl.actions import CompilationOrigin, PassType
 from mqt.predictor.rl.predictorenv import PredictorEnv
+
+if TYPE_CHECKING:
+    from qiskit.transpiler import Target
 
 
 def _setup_env(env: PredictorEnv, circuit: QuantumCircuit, layout: TranspileLayout | None, n_qubits: int) -> None:
@@ -120,16 +124,6 @@ def simple_circuit() -> QuantumCircuit:
 def env(target: Target) -> PredictorEnv:
     """Create a PredictorEnv for state-based invariant checking."""
     return PredictorEnv(device=target, reward_function="expected_fidelity")
-
-
-@pytest.fixture
-def directional_env() -> PredictorEnv:
-    """Create an environment for direction-sensitive routing actions."""
-    target = Target(num_qubits=2, description="directional test target")
-    target.add_instruction(HGate(), {(0,): None, (1,): None})
-    target.add_instruction(CXGate(), {(0, 1): None})
-    with pytest.warns(UserWarning, match="uni-directional"):
-        return PredictorEnv(device=target, reward_function="expected_fidelity")
 
 
 def test_synthesis_actions_produce_native_gates(
@@ -227,48 +221,38 @@ def test_mapping_actions_establish_layout_and_route(
 def test_routing_actions_route_circuit(
     simple_circuit: QuantumCircuit,
     env: PredictorEnv,
-    directional_env: PredictorEnv,
 ) -> None:
     """Invariant: every routing action produces a circuit where all 2-qubit gates respect the coupling map."""
+    coupling_map = env.device.build_coupling_map()
+    applied_actions = 0
+
     for idx, action in env.action_set.items():
         if action.pass_type != PassType.ROUTING:
             continue
-
         qc_laid_out, layout = _lay_out(simple_circuit, env.device)
-        directional_circuit = QuantumCircuit(2)
-        directional_circuit.cx(1, 0)
-        directional_laid_out, directional_layout = _lay_out(directional_circuit, directional_env.device)
-        test_cases = (
-            (env, qc_laid_out, layout),
-            (directional_env, directional_laid_out, directional_layout),
-        )
-
-        for action_env, circuit, action_layout in test_cases:
-            n_qubits = circuit.num_qubits
-            _setup_env(action_env, circuit, action_layout, n_qubits)
-            if _is_available(action_env, idx):
-                routed = action_env.apply_action(idx)
-                break
-        else:
-            pytest.fail(f"{action.name} was unavailable for all routing test cases")
-
-        coupling_map = action_env.device.build_coupling_map()
-        assert action_env.is_circuit_routed(routed, coupling_map), (
-            f"{action.name} on {action_env.device.description} VIOLATED INVARIANT: "
-            "circuit not properly routed after action"
+        n_qubits = qc_laid_out.num_qubits
+        _setup_env(env, qc_laid_out, layout, n_qubits)
+        if not _is_available(env, idx):
+            continue
+        routed = env.apply_action(idx)
+        applied_actions += 1
+        assert env.is_circuit_routed(routed, coupling_map), (
+            f"{action.name} on {env.device.description} VIOLATED INVARIANT: circuit not properly routed after action"
         )
         # Check BQSKit routing translates its output permutation into Qiskit layout bookkeeping correctly.
         if action.origin == CompilationOrigin.BQSKIT:
-            assert action_env.layout is not None
-            assert action_env.layout.final_layout is not None
-            assert set(action_env.layout.final_layout.get_virtual_bits()).issubset(routed.qubits)
-            assert action_env.layout._output_qubit_list == routed.qubits  # ruff: ignore[private-member-access]
+            assert env.layout is not None
+            assert env.layout.final_layout is not None
+            assert set(env.layout.final_layout.get_virtual_bits()).issubset(routed.qubits)
+            assert env.layout._output_qubit_list == routed.qubits  # ruff: ignore[private-member-access]
 
-            _setup_env(action_env, routed, action_env.layout, n_qubits)
-            rerouted = action_env.apply_action(idx)
-            assert action_env.layout.final_layout is not None
-            assert set(action_env.layout.final_layout.get_virtual_bits()).issubset(rerouted.qubits)
-            assert action_env.layout._output_qubit_list == rerouted.qubits  # ruff: ignore[private-member-access]
+            _setup_env(env, routed, env.layout, n_qubits)
+            rerouted = env.apply_action(idx)
+            assert env.layout.final_layout is not None
+            assert set(env.layout.final_layout.get_virtual_bits()).issubset(rerouted.qubits)
+            assert env.layout._output_qubit_list == rerouted.qubits  # ruff: ignore[private-member-access]
+
+    assert applied_actions > 0
 
 
 def test_optimization_actions_preserve_invariants(

--- a/tests/compilation/test_predictor_rl.py
+++ b/tests/compilation/test_predictor_rl.py
@@ -149,15 +149,32 @@ def test_qcompile_with_false_input() -> None:
         rl_compile(qc, device=None, figure_of_merit="expected_fidelity")
 
 
-def test_warning_for_unidirectional_device() -> None:
-    """Test the warning for a unidirectional device."""
+def test_unidirectional_device_warning_and_gate_direction() -> None:
+    """Test warning and gate-direction routing for a unidirectional device."""
     target = Target()
     target.add_instruction(CXGate(), {(0, 1): InstructionProperties()})
     target.description = "uni-directional device"
 
     msg = "The connectivity of the device 'uni-directional device' is uni-directional and MQT Predictor might return a compiled circuit that assumes bi-directionality."
     with pytest.warns(UserWarning, match=re.escape(msg)):
-        Predictor(figure_of_merit="expected_fidelity", device=target)
+        predictor = Predictor(figure_of_merit="expected_fidelity", device=target)
+
+    env = predictor.env
+    qc = QuantumCircuit(2)
+    qc.cx(1, 0)
+    env.reset(qc)
+    env.layout = TranspileLayout(
+        initial_layout=Layout({qubit: index for index, qubit in enumerate(qc.qubits)}),
+        input_qubit_mapping={qubit: index for index, qubit in enumerate(qc.qubits)},
+        final_layout=None,
+        _output_qubit_list=qc.qubits,
+        _input_qubit_count=qc.num_qubits,
+    )
+    env.valid_actions = env.determine_valid_actions_for_state()
+    action_index = next(index for index in env.actions_routing_indices if env.action_set[index].name == "GateDirection")
+
+    assert env.action_masks()[action_index]
+    assert env.is_circuit_routed(env.apply_action(action_index), target.build_coupling_map())
 
 
 def test_predictor_env_truncates_at_max_steps() -> None:

--- a/tests/compilation/test_predictor_rl.py
+++ b/tests/compilation/test_predictor_rl.py
@@ -149,32 +149,15 @@ def test_qcompile_with_false_input() -> None:
         rl_compile(qc, device=None, figure_of_merit="expected_fidelity")
 
 
-def test_unidirectional_device_warning_and_gate_direction() -> None:
-    """Test warning and gate-direction routing for a unidirectional device."""
+def test_warning_for_unidirectional_device() -> None:
+    """Test the warning for a unidirectional device."""
     target = Target()
     target.add_instruction(CXGate(), {(0, 1): InstructionProperties()})
     target.description = "uni-directional device"
 
     msg = "The connectivity of the device 'uni-directional device' is uni-directional and MQT Predictor might return a compiled circuit that assumes bi-directionality."
     with pytest.warns(UserWarning, match=re.escape(msg)):
-        predictor = Predictor(figure_of_merit="expected_fidelity", device=target)
-
-    env = predictor.env
-    qc = QuantumCircuit(2)
-    qc.cx(1, 0)
-    env.reset(qc)
-    env.layout = TranspileLayout(
-        initial_layout=Layout({qubit: index for index, qubit in enumerate(qc.qubits)}),
-        input_qubit_mapping={qubit: index for index, qubit in enumerate(qc.qubits)},
-        final_layout=None,
-        _output_qubit_list=qc.qubits,
-        _input_qubit_count=qc.num_qubits,
-    )
-    env.valid_actions = env.determine_valid_actions_for_state()
-    action_index = next(index for index in env.actions_routing_indices if env.action_set[index].name == "GateDirection")
-
-    assert env.action_masks()[action_index]
-    assert env.is_circuit_routed(env.apply_action(action_index), target.build_coupling_map())
+        Predictor(figure_of_merit="expected_fidelity", device=target)
 
 
 def test_predictor_env_truncates_at_max_steps() -> None:

--- a/tests/compilation/test_predictor_rl.py
+++ b/tests/compilation/test_predictor_rl.py
@@ -50,8 +50,8 @@ def test_predictor_env_reset_from_string() -> None:
         dump(qc, f)
     observation, _ = predictor.env.reset(qc=qasm_path)
 
-    assert observation == create_feature_dict(qc)
-    assert observation["num_qubits"] == qc.num_qubits
+    assert observation == create_feature_dict(qc, device.num_qubits)
+    assert observation["num_qubits"][0] == pytest.approx(qc.num_qubits / device.num_qubits)
 
 
 def test_predictor_env_esp_error() -> None:

--- a/tests/compilation/test_tracer.py
+++ b/tests/compilation/test_tracer.py
@@ -77,8 +77,8 @@ def test_compilation_tracer_generates_valid_json(tmp_path: Path) -> None:
     qc_terminal.rz(0.5, 2)
 
     # 2. Mock the feature dictionaries that the RL environment normally passes
-    features_baseline = create_feature_dict(qc_baseline)
-    features_terminal = create_feature_dict(qc_terminal)
+    features_baseline = create_feature_dict(qc_baseline, device.num_qubits)
+    features_terminal = create_feature_dict(qc_terminal, device.num_qubits)
 
     # 3. Use the actual `record_step` API instead of manually building CompilationSteps
     tracer.record_step(


### PR DESCRIPTION
🤖 *AI text below* 🤖

## Description

Creates the first downstream layer after the reviewed #758 observation PR.

This layer contains the remaining compact scalar observation encoding together with the Qiskit action and stochastic-selection changes:

- encode `num_qubits` and `depth` as normalized one-element `float32` arrays;
- add `TrivialLayout`, `ElidePermutations`, `SabreSwap`, `BasicSwap`, `LookaheadSwap`, `GateDirection`, `RemoveIdentityEquivalent`, and `Optimize1qGatesSimpleCommutation` actions;
- collect Clifford blocks before `OptimizeCliffords` and decompose its result;
- evaluate 20 candidates by default for actions marked stochastic and retain the best configured figure of merit;
- continue after individual failed candidates while propagating pass and scoring timeouts immediately.

Existing RL models must be retrained because both the observation and action schemas change. The IBM AI routing actions remain excluded because the published IBM transpiler packages conflict with the dependency versions required by this stack.

This draft depends directly on #758.

## Validation

- repository lint;
- focused observation, routing, mapping, optimization, and stochastic-action checks;
- direct pass- and scoring-timeout smokes.

Fixes #667

Part of #675

Part of #664

## Checklist

- [x] The pull request contains only the changes assigned to this stack layer.
- [x] Existing focused tests and release metadata cover the changed behavior.
- [x] The changes follow the repository style and introduce no new warnings.
- [x] I reviewed the complete base-to-head diff.

**If PR contains AI-assisted content:**

- [x] Any agent that created, edited, or submitted GitHub content was explicitly authorized for that scope.
- [x] Every agent-authored or agent-edited public text body begins with the visible disclosure `🤖 *AI text below* 🤖`.
- [ ] I confirm that I have personally reviewed and understood all AI-generated content, and accept full responsibility for it.
