### PR TITLE
✨ Add missing BQSKit RL synthesis actions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ releases may include breaking changes.
 
 ### Added
 
-- ✨ Add BQSKit's `QSDPass` and `MGDPass` to the RL synthesis actions ([#795])
+- ✨ Add BQSKit's `QSDPass` to the RL synthesis actions ([#795])
   ([**@flowerthrower**])
 - ✨ Add Qiskit's `TrivialLayout`, `ElidePermutations`, `SabreSwap`,
   `BasicSwap`, `LookaheadSwap`, `RemoveIdentityEquivalent`, and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ releases may include breaking changes.
 
 ### Added
 
+- ✨ Add BQSKit's `QSDPass` and `MGDPass` to the RL synthesis actions ([#795])
+  ([**@flowerthrower**])
 - ✨ Add Qiskit's `TrivialLayout`, `ElidePermutations`, `SabreSwap`,
   `BasicSwap`, `LookaheadSwap`, `RemoveIdentityEquivalent`, and
   `Optimize1qGatesSimpleCommutation` passes and the optional IBM-backed
@@ -100,6 +102,7 @@ for previous changelogs._
 
 [#773]: https://github.com/munich-quantum-toolkit/predictor/pull/771
 [#769]: https://github.com/munich-quantum-toolkit/predictor/pull/769
+[#795]: https://github.com/munich-quantum-toolkit/predictor/pull/795
 [#794]: https://github.com/munich-quantum-toolkit/predictor/pull/794
 [#758]: https://github.com/munich-quantum-toolkit/predictor/pull/758
 [#755]: https://github.com/munich-quantum-toolkit/predictor/pull/755

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -67,7 +67,8 @@ The new actions include:
 - the `GeneralizedSabreRoutingPass` routing action;
 - the `BQSKitSABREMapping` mapping action; and
 - the `QSearchSynthesisPass`, `LEAPSynthesisPass`, `WalshDiagonalSynthesisPass`,
-  `FullQSDPass`, `BlockZXZPass`, and `FullBlockZXZPass` synthesis actions.
+  `QSDPass`, `MGDPass`, `FullQSDPass`, `BlockZXZPass`, and `FullBlockZXZPass`
+  synthesis actions.
 
 See the
 [framework setup](docs/setup.md#step-2-train-reinforcement-learning-models) for

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -67,8 +67,8 @@ The new actions include:
 - the `GeneralizedSabreRoutingPass` routing action;
 - the `BQSKitSABREMapping` mapping action; and
 - the `QSearchSynthesisPass`, `LEAPSynthesisPass`, `WalshDiagonalSynthesisPass`,
-  `QSDPass`, `MGDPass`, `FullQSDPass`, `BlockZXZPass`, and `FullBlockZXZPass`
-  synthesis actions.
+  `QSDPass`, `FullQSDPass`, `BlockZXZPass`, and `FullBlockZXZPass` synthesis
+  actions.
 
 See the
 [framework setup](docs/setup.md#step-2-train-reinforcement-learning-models) for

--- a/src/mqt/predictor/rl/actions/bqskit_actions.py
+++ b/src/mqt/predictor/rl/actions/bqskit_actions.py
@@ -39,6 +39,8 @@ from bqskit.passes import (
     IfThenElsePass,
     LEAPSynthesisPass,
     ManyQuditGatesPredicate,
+    MGDPass,
+    QSDPass,
     QSearchSynthesisPass,
     RestoreMeasurements,
     SetModelPass,
@@ -308,6 +310,21 @@ def bqskit_synthesis_actions() -> list[Action]:
                 device,
                 IfThenElsePass(DiagonalPredicate(1e-9), WalshDiagonalSynthesisPass()),
             ),
+        ),
+        DeferredDeviceAction(
+            "QSDPass",
+            CompilationOrigin.BQSKIT,
+            PassType.SYNTHESIS,
+            transpile_pass=lambda device: _bqskit_partitioned_synthesis_factory(
+                device,
+                QSDPass(min_qudit_size=_BQSKIT_BLOCK_SIZE - 1),
+            ),
+        ),
+        DeferredDeviceAction(
+            "MGDPass",
+            CompilationOrigin.BQSKIT,
+            PassType.SYNTHESIS,
+            transpile_pass=lambda device: _bqskit_partitioned_synthesis_factory(device, MGDPass()),
         ),
         DeferredDeviceAction(
             "FullQSDPass",

--- a/src/mqt/predictor/rl/actions/bqskit_actions.py
+++ b/src/mqt/predictor/rl/actions/bqskit_actions.py
@@ -15,7 +15,7 @@ import re
 from functools import cache
 from typing import TYPE_CHECKING, TypeAlias, cast
 
-from bqskit import MachineModel
+from bqskit import Circuit, MachineModel
 from bqskit.compiler import Compiler, Workflow
 from bqskit.compiler.compile import (
     build_multi_qudit_retarget_workflow,
@@ -39,13 +39,13 @@ from bqskit.passes import (
     IfThenElsePass,
     LEAPSynthesisPass,
     ManyQuditGatesPredicate,
-    MGDPass,
     QSDPass,
     QSearchSynthesisPass,
     RestoreMeasurements,
     SetModelPass,
     SetRandomSeedPass,
     StaticPlacementPass,
+    SynthesisPass,
     TrivialPlacementPass,
     UnfoldPass,
     WalshDiagonalSynthesisPass,
@@ -61,11 +61,11 @@ from mqt.predictor.rl.actions.base import CompilationOrigin, DeferredDeviceActio
 if TYPE_CHECKING:
     from collections.abc import Callable
 
-    from bqskit import Circuit
     from bqskit.compiler.basepass import BasePass
     from bqskit.compiler.passdata import PassData
     from bqskit.compiler.workflow import WorkflowLike
     from bqskit.ir import Gate
+    from bqskit.qis import StateSystem, StateVector, UnitaryMatrix
     from qiskit import QuantumCircuit
     from qiskit.circuit import Qubit as QiskitQubit
     from qiskit.transpiler import Target
@@ -81,6 +81,22 @@ _BQSKIT_BLOCK_SIZE = 3
 _BQSKIT_SEARCH_MAX_LAYER = 3
 _BQSKIT_SEED = 10
 _BQSKIT_NUM_WORKERS = 1 if os.getenv("GITHUB_ACTIONS") == "true" else -1
+
+
+class _QSDUnitarySynthesisPass(SynthesisPass):
+    """Apply one QSD level to each multi-qubit synthesis target."""
+
+    async def synthesize(
+        self,
+        target: UnitaryMatrix | StateVector | StateSystem,
+        data: PassData,
+    ) -> Circuit:
+        """Synthesize a partition target with one QSD level."""
+        del data
+        unitary = cast("UnitaryMatrix", target)
+        if unitary.num_qudits == 1:
+            return Circuit.from_unitary(unitary)
+        return QSDPass.qsd(unitary)
 
 
 def _r_gate(theta: float, phi: float) -> Instruction:
@@ -315,16 +331,7 @@ def bqskit_synthesis_actions() -> list[Action]:
             "QSDPass",
             CompilationOrigin.BQSKIT,
             PassType.SYNTHESIS,
-            transpile_pass=lambda device: _bqskit_partitioned_synthesis_factory(
-                device,
-                QSDPass(min_qudit_size=_BQSKIT_BLOCK_SIZE - 1),
-            ),
-        ),
-        DeferredDeviceAction(
-            "MGDPass",
-            CompilationOrigin.BQSKIT,
-            PassType.SYNTHESIS,
-            transpile_pass=lambda device: _bqskit_partitioned_synthesis_factory(device, MGDPass()),
+            transpile_pass=lambda device: _bqskit_partitioned_synthesis_factory(device, _QSDUnitarySynthesisPass()),
         ),
         DeferredDeviceAction(
             "FullQSDPass",

--- a/tests/compilation/test_integration_further_SDKs.py
+++ b/tests/compilation/test_integration_further_SDKs.py
@@ -10,9 +10,12 @@
 
 from __future__ import annotations
 
+import asyncio
 from typing import TYPE_CHECKING
 
 import pytest
+from bqskit.compiler.passdata import PassData
+from bqskit.ir.gates import MPRYGate, MPRZGate, VariableUnitaryGate
 from mqt.bench.targets import get_device
 from qiskit import QuantumCircuit
 from qiskit.circuit import StandardEquivalenceLibrary
@@ -26,7 +29,7 @@ from qiskit.transpiler.passes import (
     TrivialLayout,
 )
 
-from mqt.predictor.rl.actions import CompilationOrigin, PassType
+from mqt.predictor.rl.actions import CompilationOrigin, PassType, bqskit_actions
 from mqt.predictor.rl.predictorenv import PredictorEnv
 
 if TYPE_CHECKING:
@@ -124,6 +127,22 @@ def simple_circuit() -> QuantumCircuit:
 def env(target: Target) -> PredictorEnv:
     """Create a PredictorEnv for state-based invariant checking."""
     return PredictorEnv(device=target, reward_function="expected_fidelity")
+
+
+@pytest.mark.filterwarnings("ignore:__array__ implementation doesn't accept a copy keyword:DeprecationWarning")
+def test_qsd_unitary_synthesis_pass_applies_one_qsd_level(simple_circuit: QuantumCircuit) -> None:
+    """The QSD adapter performs one equivalent decomposition of a reachable partition target."""
+    bqskit_circuit = bqskit_actions.qiskit_to_bqskit(simple_circuit)
+    unitary = bqskit_circuit.get_unitary()
+    synthesis_pass = bqskit_actions._QSDUnitarySynthesisPass()  # ruff: ignore[private-member-access]
+
+    decomposed = asyncio.run(synthesis_pass.synthesize(unitary, PassData(bqskit_circuit)))
+
+    assert decomposed.get_unitary().get_distance_from(unitary) < 1e-7
+    assert sum(count for gate, count in decomposed.gate_counts.items() if isinstance(gate, VariableUnitaryGate)) == 4
+    assert all(gate.num_qudits == 2 for gate in decomposed.gate_set if isinstance(gate, VariableUnitaryGate))
+    assert sum(count for gate, count in decomposed.gate_counts.items() if isinstance(gate, MPRZGate)) == 2
+    assert sum(count for gate, count in decomposed.gate_counts.items() if isinstance(gate, MPRYGate)) == 1
 
 
 def test_synthesis_actions_produce_native_gates(


### PR DESCRIPTION
🤖 *AI text below* 🤖

## Description

Adds BQSKit's `QSDPass` as an RL synthesis action.

The existing partitioned-synthesis workflow supplies ordinary circuit targets to its inner pass. Stock `QSDPass` only scans existing `VariableUnitaryGate` operations, so changing `min_qudit_size` does not make it run on circuits entering through the Qiskit/QASM2 path. A small `SynthesisPass` adapter now applies one `QSDPass.qsd` level to each reachable multi-qubit partition target while retaining the established partitioning, seed, retargeting, measurement, and target-native-output workflow.

`MGDPass` is intentionally not registered: it only consumes BQSKit-internal `MPRYGate` and `MPRZGate` operations, which cannot enter through the public Qiskit/QASM2 state.

A focused regression verifies unitary preservation and the exact one-level QSD structure. The existing synthesis integration test verifies that the registered action produces target-native output. The lint suite passes.

The added action changes the RL action schema, so existing models must be retrained. No package dependencies are added.

This is position 4 of the stack. It depends on #794 and is followed by #796.

Part of #664

## Checklist

- [x] The pull request only contains commits that are focused and relevant to this change.
- [x] I have added appropriate tests that cover the new/changed functionality.
- [x] I have updated the documentation to reflect these changes.
- [x] I have added entries to the changelog for any noteworthy additions, changes, fixes, or removals.
- [x] I have added migration instructions to the upgrade guide (if needed).
- [x] The changes follow the project's style guidelines and introduce no new warnings.
- [ ] The changes are fully tested and pass the CI checks.
- [ ] I have reviewed my own code changes.

**If PR contains AI-assisted content:**

- [x] Any agent that created, edited, or submitted GitHub content was explicitly authorized for that scope, as required by our [AI Usage Guidelines](https://github.com/munich-quantum-toolkit/predictor/blob/main/docs/ai_usage.md).
- [x] Every agent-authored or agent-edited public text body begins with the visible disclosure `🤖 *AI text below* 🤖` (titles are exempt).
- [x] I have disclosed AI assistance in the PR description.
- [ ] I confirm that I have personally reviewed and understood all AI-generated content, and accept full responsibility for it.
