### PR TITLE
🐛 Make RL sampling and Qiskit actions user-seedable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,9 +32,9 @@ releases may include breaking changes.
 
 ### Changed
 
-- 🐛 Restore nondeterministic RL circuit sampling without a seed and make
-  explicitly seeded sampling and randomized Qiskit actions reproducible ([#797])
-  ([**@flowerthrower**])
+- 🐛 Restore nondeterministic RL circuit sampling and inference without a seed,
+  and make explicitly seeded training, deterministic inference, and randomized
+  Qiskit actions reproducible ([#797]) ([**@flowerthrower**])
 - 🐛 Mask TKET layout and routing actions for circuits containing operations
   wider than two qubits ([#796]) ([**@flowerthrower**])
 - 🐛 Make the `OptimizeCliffords` RL action collect standard Clifford gates

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,9 @@ releases may include breaking changes.
 
 ### Changed
 
+- 🐛 Restore nondeterministic RL circuit sampling without a seed and make
+  explicitly seeded sampling and randomized Qiskit actions reproducible ([#797])
+  ([**@flowerthrower**])
 - 🐛 Mask TKET layout and routing actions for circuits containing operations
   wider than two qubits ([#796]) ([**@flowerthrower**])
 - 🐛 Make the `OptimizeCliffords` RL action collect standard Clifford gates
@@ -106,6 +109,7 @@ for previous changelogs._
 
 [#773]: https://github.com/munich-quantum-toolkit/predictor/pull/771
 [#769]: https://github.com/munich-quantum-toolkit/predictor/pull/769
+[#797]: https://github.com/munich-quantum-toolkit/predictor/pull/797
 [#796]: https://github.com/munich-quantum-toolkit/predictor/pull/796
 [#795]: https://github.com/munich-quantum-toolkit/predictor/pull/795
 [#794]: https://github.com/munich-quantum-toolkit/predictor/pull/794

--- a/src/mqt/predictor/rl/actions/qiskit_actions.py
+++ b/src/mqt/predictor/rl/actions/qiskit_actions.py
@@ -512,12 +512,25 @@ def _postprocess_layout_action(
     return altered_qc, layout
 
 
+def _seed_randomized_passes(passes: list[Task], seed: int) -> None:
+    """Seed randomized Qiskit passes with CPU-independent trial counts."""
+    for transpiler_pass in passes:
+        if isinstance(transpiler_pass, (SabreLayout, SabreSwap, VF2Layout, VF2PostLayout)):
+            transpiler_pass.seed = seed
+        if isinstance(transpiler_pass, SabreLayout):
+            transpiler_pass.layout_trials = 1
+            transpiler_pass.swap_trials = 1
+        elif isinstance(transpiler_pass, SabreSwap):
+            transpiler_pass.trials = 1
+
+
 def run_qiskit_action(
     action: Action,
     circuit: QuantumCircuit,
     device: Target,
     layout: TranspileLayout | None,
     input_qubit_count: int | None = None,
+    seed: int | None = None,
 ) -> tuple[QuantumCircuit, TranspileLayout | None]:
     """Apply a Qiskit action and return the updated circuit and layout metadata."""
     # Build the concrete Qiskit pass list for given action.
@@ -529,6 +542,9 @@ def run_qiskit_action(
         passes = factory(device)
     else:
         passes = cast("list[Task]", action.transpile_pass)
+
+    if seed is not None:
+        _seed_randomized_passes(passes, seed)
 
     if action.name == "QiskitO3" and isinstance(action, DeferredDeviceAction):
         assert action.do_while is not None

--- a/src/mqt/predictor/rl/helper.py
+++ b/src/mqt/predictor/rl/helper.py
@@ -47,14 +47,14 @@ def get_state_sample(max_qubits: int, path_training_circuits: Path, rng: Generat
     Raises:
         RuntimeError: If no quantum circuit could be read from the training circuits folder.
     """
-    file_list = list(path_training_circuits.glob("*.qasm"))
+    file_list = sorted(path_training_circuits.glob("*.qasm"))
 
     path_zip = path_training_circuits / "training_data_compilation.zip"
     if len(file_list) == 0 and path_zip.exists():
         with zipfile.ZipFile(str(path_zip), "r") as zip_ref:
             zip_ref.extractall(path_training_circuits)
 
-        file_list = list(path_training_circuits.glob("*.qasm"))
+        file_list = sorted(path_training_circuits.glob("*.qasm"))
         assert len(file_list) > 0
 
     found_suitable_qc = False

--- a/src/mqt/predictor/rl/predictor.py
+++ b/src/mqt/predictor/rl/predictor.py
@@ -86,6 +86,7 @@ class Predictor:
             RuntimeError: If an error occurs during compilation.
         """
         original_tracer_output_path = self.env.tracer_output_path
+        original_seed_qiskit_actions = self.env.configure_qiskit_action_seeding(enabled=False)
 
         # Temporarily override singleton if a new path is explicitly provided
         if tracer_output_path is not None:
@@ -94,7 +95,7 @@ class Predictor:
         try:
             trained_rl_model = load_model(self.model_name)
 
-            obs, _ = self.env.reset(qc, seed=0)
+            obs, _ = self.env.reset(qc)
 
             used_compilation_passes = []
             terminated = False
@@ -116,6 +117,7 @@ class Predictor:
         finally:
             # Restore original singleton path
             self.env.tracer_output_path = original_tracer_output_path
+            self.env.configure_qiskit_action_seeding(enabled=original_seed_qiskit_actions)
 
     def train_model(
         self,
@@ -133,6 +135,7 @@ class Predictor:
             seed: The random seed to use for reproducible training. Set to None to use true randomness.
                 Defaults to None.
         """
+        self.env.configure_qiskit_action_seeding(enabled=seed is not None)
         if seed is not None:
             set_random_seed(seed)
         if test:

--- a/src/mqt/predictor/rl/predictor.py
+++ b/src/mqt/predictor/rl/predictor.py
@@ -72,12 +72,14 @@ class Predictor:
         self,
         qc: QuantumCircuit | str,
         tracer_output_path: str | Path | None = None,
+        seed: int | None = None,
     ) -> tuple[QuantumCircuit, list[str]]:
         """Compiles a given quantum circuit such that the given figure of merit is maximized by using the respectively trained optimized compiler.
 
         Arguments:
             qc: The quantum circuit to be compiled or the path to a qasm file containing the quantum circuit.
             tracer_output_path: Optional temporary path to export the compilation trace for this specific run.
+            seed: The seed for reproducible deterministic inference and randomized Qiskit actions. Defaults to None.
 
         Returns:
             A tuple containing the compiled quantum circuit and the compilation information. If compilation fails, False is returned.
@@ -86,7 +88,7 @@ class Predictor:
             RuntimeError: If an error occurs during compilation.
         """
         original_tracer_output_path = self.env.tracer_output_path
-        original_seed_qiskit_actions = self.env.configure_qiskit_action_seeding(enabled=False)
+        original_seed_qiskit_actions = self.env.configure_qiskit_action_seeding(enabled=seed is not None)
 
         # Temporarily override singleton if a new path is explicitly provided
         if tracer_output_path is not None:
@@ -95,14 +97,18 @@ class Predictor:
         try:
             trained_rl_model = load_model(self.model_name)
 
-            obs, _ = self.env.reset(qc)
+            obs, _ = self.env.reset(qc, seed=seed)
 
             used_compilation_passes = []
             terminated = False
             truncated = False
             while not (terminated or truncated):
                 action_masks = get_action_masks(self.env)
-                action, _ = trained_rl_model.predict(obs, action_masks=action_masks)
+                action, _ = trained_rl_model.predict(
+                    obs,
+                    deterministic=seed is not None,
+                    action_masks=action_masks,
+                )
                 action = int(action)
                 action_item = self.env.action_set[action]
                 used_compilation_passes.append(action_item.name)
@@ -197,6 +203,7 @@ def rl_compile(
     predictor_singleton: Predictor | None = None,
     tracer_output_path: str | Path | None = None,
     mdp: MDPPolicy = "v3",
+    seed: int | None = None,
 ) -> tuple[QuantumCircuit, list[str]]:
     """Compiles a given quantum circuit to a device optimizing for the given figure of merit.
 
@@ -209,6 +216,7 @@ def rl_compile(
         mdp: The MDP transition policy used when constructing a predictor. ``v2``
             is the original strategy and ``v3`` is the default. When
             ``predictor_singleton`` is provided, its configured policy is used instead.
+        seed: The seed for reproducible deterministic inference and randomized Qiskit actions. Defaults to None.
 
     Returns:
         A tuple containing the compiled quantum circuit and the compilation information. If compilation fails, False is returned.
@@ -229,6 +237,6 @@ def rl_compile(
             tracer_output_path=tracer_output_path,
             mdp=mdp,
         )
-        return predictor.compile_as_predicted(qc)
+        return predictor.compile_as_predicted(qc, seed=seed)
 
-    return predictor_singleton.compile_as_predicted(qc, tracer_output_path=tracer_output_path)
+    return predictor_singleton.compile_as_predicted(qc, tracer_output_path=tracer_output_path, seed=seed)

--- a/src/mqt/predictor/rl/predictorenv.py
+++ b/src/mqt/predictor/rl/predictorenv.py
@@ -177,7 +177,7 @@ class PredictorEnv(Env):
         self.layout: TranspileLayout | None = None
 
         self.has_parameterized_gates = False
-        self.rng = np.random.default_rng(10)
+        self._seed_qiskit_actions = False
 
         operation_spaces = {
             operation: Box(low=0, high=1, shape=(1,), dtype=np.float32) for operation in OBSERVATION_OPERATIONS
@@ -201,6 +201,12 @@ class PredictorEnv(Env):
 
         self.observation_space = Dict(spaces)
         self.filename = ""
+
+    def configure_qiskit_action_seeding(self, *, enabled: bool) -> bool:
+        """Configure Qiskit action seeding and return the previous setting."""
+        previous = self._seed_qiskit_actions
+        self._seed_qiskit_actions = enabled
+        return previous
 
     def _collect_tracer_data(
         self,
@@ -410,6 +416,8 @@ class PredictorEnv(Env):
             The initial state and additional information.
         """
         super().reset(seed=seed)
+        if seed is not None:
+            self._seed_qiskit_actions = True
         if isinstance(qc, QuantumCircuit):
             self.state = qc
             self.filename = ""
@@ -419,7 +427,11 @@ class PredictorEnv(Env):
             self.filename = str(qc)
             current_circuit_name = Path(str(qc)).stem
         else:
-            self.state, self.filename = get_state_sample(self.device.num_qubits, self.path_training_circuits, self.rng)
+            self.state, self.filename = get_state_sample(
+                self.device.num_qubits,
+                self.path_training_circuits,
+                self.np_random,
+            )
             current_circuit_name = Path(self.filename).stem
 
         self.action_space = Discrete(len(self.action_set.keys()))
@@ -556,6 +568,7 @@ class PredictorEnv(Env):
                 device=self.device,
                 layout=self.layout,
                 input_qubit_count=self.num_qubits_uncompiled_circuit,
+                seed=(int(self.np_random.integers(0, np.iinfo(np.int32).max)) if self._seed_qiskit_actions else None),
             )
         elif action.origin == CompilationOrigin.TKET:
             altered_qc, self.layout = run_tket_action(

--- a/tests/compilation/test_predictor_rl.py
+++ b/tests/compilation/test_predictor_rl.py
@@ -362,18 +362,20 @@ def test_predictor_env_qiskit_action_seeds_are_opt_in(monkeypatch: pytest.Monkey
 
 
 def test_predictor_scopes_qiskit_action_seeding(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Test that unseeded top-level operations disable prior seeded mode."""
+    """Test that a compilation seed enables deterministic inference and seeded actions."""
     predictor = Predictor(figure_of_merit="expected_fidelity", device=get_device("ibm_falcon_27"))
     predictor.env.reset(QuantumCircuit(1), seed=123)
-    observed_modes: list[bool] = []
+    observed_inference_modes: list[tuple[bool, bool]] = []
+    observed_training_modes: list[bool] = []
 
     class TerminatingModel:
         """Return the terminate action immediately."""
 
         @staticmethod
-        def predict(_observation: object, action_masks: object) -> tuple[int, None]:
+        def predict(_observation: object, *, deterministic: bool, action_masks: object) -> tuple[int, None]:
             assert action_masks is not None
-            observed_modes.append(predictor.env.configure_qiskit_action_seeding(enabled=False))
+            qiskit_actions_seeded = predictor.env.configure_qiskit_action_seeding(enabled=False)
+            observed_inference_modes.append((deterministic, qiskit_actions_seeded))
             return predictor.env.action_terminate_index, None
 
     class NoOpModel:
@@ -381,7 +383,7 @@ def test_predictor_scopes_qiskit_action_seeding(monkeypatch: pytest.MonkeyPatch)
 
         def __init__(self, *args: object, **_kwargs: object) -> None:
             env = cast("PredictorEnv", args[1])
-            observed_modes.append(env.configure_qiskit_action_seeding(enabled=False))
+            observed_training_modes.append(env.configure_qiskit_action_seeding(enabled=False))
 
         def learn(self, *_args: object, **_kwargs: object) -> None:
             pass
@@ -392,11 +394,14 @@ def test_predictor_scopes_qiskit_action_seeding(monkeypatch: pytest.MonkeyPatch)
     monkeypatch.setattr(predictor_module, "load_model", lambda _model_name: TerminatingModel())
     predictor.compile_as_predicted(QuantumCircuit(1))
     assert predictor.env.configure_qiskit_action_seeding(enabled=True)
+    rl_compile(QuantumCircuit(1), device=None, predictor_singleton=predictor, seed=123)
+    assert predictor.env.configure_qiskit_action_seeding(enabled=True)
 
     monkeypatch.setattr(predictor_module, "MaskablePPO", NoOpModel)
     predictor.train_model(timesteps=1, test=True)
 
-    assert observed_modes == [False, False]
+    assert observed_inference_modes == [(False, False), (True, True)]
+    assert observed_training_modes == [False]
 
 
 def test_seed_randomized_qiskit_passes() -> None:

--- a/tests/compilation/test_predictor_rl.py
+++ b/tests/compilation/test_predictor_rl.py
@@ -24,22 +24,26 @@ from qiskit.circuit.library import CXGate
 from qiskit.qasm2 import dump
 from qiskit.quantum_info import Clifford
 from qiskit.transpiler import InstructionProperties, Layout, Target, TranspileLayout
-from qiskit.transpiler.passes import GatesInBasis
+from qiskit.transpiler.passes import GatesInBasis, SabreLayout, SabreSwap, VF2Layout, VF2PostLayout
 
 from mqt.predictor.rl import Predictor, rl_compile
+from mqt.predictor.rl import predictor as predictor_module
 from mqt.predictor.rl import predictorenv as predictorenv_module
 from mqt.predictor.rl.actions import (
     CompilationOrigin,
     DeviceIndependentAction,
     PassType,
     get_actions_by_pass_type,
+    qiskit_actions,
     register_action,
 )
 from mqt.predictor.rl.actions import registry as actions_registry_module
 from mqt.predictor.rl.helper import create_feature_dict, get_path_trained_model
 
 if TYPE_CHECKING:
-    from mqt.predictor.rl.predictorenv import MDPPolicy
+    from numpy.random import Generator
+
+    from mqt.predictor.rl.predictorenv import MDPPolicy, PredictorEnv
 
 
 def test_predictor_env_reset_from_string() -> None:
@@ -313,6 +317,103 @@ def test_clifford_decomposition_is_scoped_to_optimize_cliffords() -> None:
     )
     optimized = env.apply_action(optimize_cliffords_index)
     assert "clifford" not in optimized.count_ops()
+
+
+def test_predictor_env_qiskit_action_seeds_are_opt_in(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Test default randomness and reproducible user-seeded resets."""
+    captured_seeds: list[int | None] = []
+    captured_samples: list[int] = []
+
+    def fake_run_qiskit_action(**kwargs: object) -> tuple[QuantumCircuit, TranspileLayout | None]:
+        captured_seeds.append(cast("int | None", kwargs["seed"]))
+        return cast("QuantumCircuit", kwargs["circuit"]), cast("TranspileLayout | None", kwargs["layout"])
+
+    def fake_get_state_sample(_max_qubits: int, _path: Path, rng: Generator) -> tuple[QuantumCircuit, str]:
+        captured_samples.append(int(rng.integers(0, 1000)))
+        return QuantumCircuit(2), "sample.qasm"
+
+    monkeypatch.setattr(predictorenv_module, "run_qiskit_action", fake_run_qiskit_action)
+    monkeypatch.setattr(predictorenv_module, "get_state_sample", fake_get_state_sample)
+
+    env = predictorenv_module.PredictorEnv(device=get_device("ibm_falcon_27"))
+    action_index = next(index for index, action in env.action_set.items() if action.origin == CompilationOrigin.QISKIT)
+    env.reset()
+    env.apply_action(action_index)
+
+    assert captured_seeds == [None]
+    captured_seeds.clear()
+    captured_samples.clear()
+
+    for _ in range(2):
+        env = predictorenv_module.PredictorEnv(device=get_device("ibm_falcon_27"))
+        action_index = next(
+            index for index, action in env.action_set.items() if action.origin == CompilationOrigin.QISKIT
+        )
+        env.reset(seed=123)
+        env.apply_action(action_index)
+        env.apply_action(action_index)
+        env.reset()
+        env.apply_action(action_index)
+
+    assert captured_seeds[:3] == captured_seeds[3:]
+    assert all(seed is not None for seed in captured_seeds)
+    assert captured_seeds[0] != captured_seeds[1]
+    assert captured_samples[:2] == captured_samples[2:]
+
+
+def test_predictor_scopes_qiskit_action_seeding(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Test that unseeded top-level operations disable prior seeded mode."""
+    predictor = Predictor(figure_of_merit="expected_fidelity", device=get_device("ibm_falcon_27"))
+    predictor.env.reset(QuantumCircuit(1), seed=123)
+    observed_modes: list[bool] = []
+
+    class TerminatingModel:
+        """Return the terminate action immediately."""
+
+        @staticmethod
+        def predict(_observation: object, action_masks: object) -> tuple[int, None]:
+            assert action_masks is not None
+            observed_modes.append(predictor.env.configure_qiskit_action_seeding(enabled=False))
+            return predictor.env.action_terminate_index, None
+
+    class NoOpModel:
+        """Record the environment mode without training a model."""
+
+        def __init__(self, *args: object, **_kwargs: object) -> None:
+            env = cast("PredictorEnv", args[1])
+            observed_modes.append(env.configure_qiskit_action_seeding(enabled=False))
+
+        def learn(self, *_args: object, **_kwargs: object) -> None:
+            pass
+
+        def save(self, *_args: object, **_kwargs: object) -> None:
+            pass
+
+    monkeypatch.setattr(predictor_module, "load_model", lambda _model_name: TerminatingModel())
+    predictor.compile_as_predicted(QuantumCircuit(1))
+    assert predictor.env.configure_qiskit_action_seeding(enabled=True)
+
+    monkeypatch.setattr(predictor_module, "MaskablePPO", NoOpModel)
+    predictor.train_model(timesteps=1, test=True)
+
+    assert observed_modes == [False, False]
+
+
+def test_seed_randomized_qiskit_passes() -> None:
+    """Test native Qiskit seeds and CPU-independent SABRE trial counts."""
+    device = get_device("ibm_falcon_27")
+    coupling_map = device.build_coupling_map()
+    passes_and_trial_attributes = [
+        (VF2Layout(target=device), ()),
+        (VF2PostLayout(target=device), ()),
+        (SabreSwap(coupling_map=coupling_map), ("trials",)),
+        (SabreLayout(coupling_map=coupling_map), ("layout_trials", "swap_trials")),
+    ]
+
+    for transpiler_pass, trial_attributes in passes_and_trial_attributes:
+        qiskit_actions._seed_randomized_passes([transpiler_pass], seed=123)  # ruff: ignore[private-member-access]
+        assert transpiler_pass.seed == 123
+        assert all(getattr(transpiler_pass, attribute) == 1 for attribute in trial_attributes)
 
 
 def test_register_action(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
🤖 *AI text below* 🤖

## Description

Makes RL training-circuit sampling, seeded inference, and Qiskit's randomized
passes reproducible only when the user supplies a seed.

On a fresh environment, `reset()` uses Gymnasium's entropy-seeded generator for
circuit sampling and passes no seed to Qiskit. Native pass settings therefore
remain unchanged, including SABRE's CPU-dependent trial defaults.
`Predictor.train_model(seed=...)` and `PredictorEnv.reset(seed=...)` opt into
reproducible mode: they control circuit selection and supply derived native
seeds to `QiskitSabreMapping`, `SabreSwap`, `VF2Layout`, and `VF2PostLayout`.
Later seedless resets continue the initialized Gymnasium RNG stream, matching
Gymnasium and Stable-Baselines3.

Seeded SABRE execution uses one native layout and swap trial so results do not
depend on CPU-count-based defaults. Candidate QASM paths are sorted before
indexed selection. `compile_as_predicted` retains stochastic policy and native
pass behavior by default; supplying `seed=...` selects deterministic masked
argmax inference and reproducibly seeds randomized Qiskit actions.

This does not add the repeated figure-of-merit-aware wrapper tracked in #667,
change BQSKit's established fixed pass seed, or alter unrelated ML estimators.

This is position 6 of the stack. It depends on #796 and is followed by #798. No
new package dependencies are introduced.

Part of #664

## Checklist

- [x] The pull request only contains commits that are focused and relevant to this change.
- [x] I have added appropriate tests that cover the new/changed functionality.
- [ ] I have updated the documentation to reflect these changes.
- [x] I have added entries to the changelog for any noteworthy additions, changes, fixes, or removals.
- [x] I have added migration instructions to the upgrade guide (if needed).
- [x] The changes follow the project's style guidelines and introduce no new warnings.
- [ ] The changes are fully tested and pass the CI checks.
- [ ] I have reviewed my own code changes.

**If PR contains AI-assisted content:**

- [x] Any agent that created, edited, or submitted GitHub content was explicitly authorized for that scope, as required by our [AI Usage Guidelines](https://github.com/munich-quantum-toolkit/predictor/blob/main/docs/ai_usage.md).
- [x] Every agent-authored or agent-edited public text body begins with the visible disclosure `🤖 *AI text below* 🤖` (titles are exempt).
- [x] I have disclosed AI assistance in the PR description.
- [ ] I confirm that I have personally reviewed and understood all AI-generated content, and accept full responsibility for it.
