### PR TITLE
✨ Add configurable RL pass timeouts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ releases may include breaking changes.
 
 ### Added
 
+- ✨ Add opt-in per-pass timeouts for RL training and inference ([#778])
+  ([**@flowerthrower**])
 - ✨ Add TKET's `KAKDecomposition`, `GraphPlacement`, and `NoiseAwarePlacement`
   passes to the RL actions ([#796]) ([**@flowerthrower**])
 - ✨ Add BQSKit's `QSDPass` to the RL synthesis actions ([#795])
@@ -107,6 +109,7 @@ for previous changelogs._
 
 <!-- PR links -->
 
+[#778]: https://github.com/munich-quantum-toolkit/predictor/pull/778
 [#773]: https://github.com/munich-quantum-toolkit/predictor/pull/771
 [#769]: https://github.com/munich-quantum-toolkit/predictor/pull/769
 [#797]: https://github.com/munich-quantum-toolkit/predictor/pull/797

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ releases may include breaking changes.
 
 ### Added
 
-- ✨ Add opt-in per-pass timeouts for RL training and inference ([#778])
+- ✨ Add opt-in per-pass timeouts for RL training and inference ([#798])
   ([**@flowerthrower**])
 - ✨ Add TKET's `KAKDecomposition`, `GraphPlacement`, and `NoiseAwarePlacement`
   passes to the RL actions ([#796]) ([**@flowerthrower**])
@@ -109,7 +109,7 @@ for previous changelogs._
 
 <!-- PR links -->
 
-[#778]: https://github.com/munich-quantum-toolkit/predictor/pull/778
+[#798]: https://github.com/munich-quantum-toolkit/predictor/pull/798
 [#773]: https://github.com/munich-quantum-toolkit/predictor/pull/771
 [#769]: https://github.com/munich-quantum-toolkit/predictor/pull/769
 [#797]: https://github.com/munich-quantum-toolkit/predictor/pull/797

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -49,9 +49,10 @@ rl_pred.train_model(timesteps=100000, pass_timeout=600)
 ```
 
 `pass_timeout` is optional and applies the same limit to each compilation pass
-during training. If it is omitted, pass execution is unbounded. Pass timeouts
-require POSIX signals and execution on the main thread; unsupported environments
-emit a warning and continue without a timeout.
+during training. If it is omitted, pass execution is unbounded. Passes without a
+native timeout rely on POSIX signals and execution on the main thread;
+unsupported environments emit a warning and continue without that fallback
+timeout.
 
 Currently, the following figures of merit are supported:
 

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -45,8 +45,13 @@ from mqt.bench.targets import get_device
 
 device = get_device("ibm_falcon_27")
 rl_pred = RL_Predictor(device=device, figure_of_merit="expected_fidelity")
-rl_pred.train_model(timesteps=100000)
+rl_pred.train_model(timesteps=100000, pass_timeout=600)
 ```
+
+`pass_timeout` is optional and limits each compilation pass during training. If
+it is omitted, pass execution is unbounded. Pass timeouts require POSIX signals
+and execution on the main thread; unsupported environments emit a warning and
+continue without a timeout.
 
 Currently, the following figures of merit are supported:
 
@@ -121,8 +126,15 @@ from mqt.predictor import qcompile
 from mqt.bench import get_benchmark, BenchmarkLevel
 
 uncompiled_qc = get_benchmark("ghz", level=BenchmarkLevel.ALG, circuit_size=5)
-compiled_qc, compilation_info, selected_device = qcompile(uncompiled_qc, figure_of_merit="expected_fidelity")
+compiled_qc, compilation_info, selected_device = qcompile(
+    uncompiled_qc,
+    figure_of_merit="expected_fidelity",
+    pass_timeout=60,
+)
 ```
+
+Inference has its own optional `pass_timeout`, so it can use a different limit
+than training.
 
 This returns:
 

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -48,10 +48,10 @@ rl_pred = RL_Predictor(device=device, figure_of_merit="expected_fidelity")
 rl_pred.train_model(timesteps=100000, pass_timeout=600)
 ```
 
-`pass_timeout` is optional and limits each compilation pass during training. If
-it is omitted, pass execution is unbounded. Pass timeouts require POSIX signals
-and execution on the main thread; unsupported environments emit a warning and
-continue without a timeout.
+`pass_timeout` is optional and applies the same limit to each compilation pass
+during training. If it is omitted, pass execution is unbounded. Pass timeouts
+require POSIX signals and execution on the main thread; unsupported environments
+emit a warning and continue without a timeout.
 
 Currently, the following figures of merit are supported:
 

--- a/src/mqt/predictor/qcompile.py
+++ b/src/mqt/predictor/qcompile.py
@@ -27,6 +27,7 @@ def qcompile(
     qc: QuantumCircuit,
     figure_of_merit: figure_of_merit = "expected_fidelity",
     tracer_output_path: str | Path | None = None,
+    pass_timeout: float | None = None,
 ) -> tuple[QuantumCircuit, list[str], str]:
     """Compiles a given quantum circuit to a device with the highest predicted figure of merit.
 
@@ -34,12 +35,21 @@ def qcompile(
         qc: The quantum circuit to be compiled.
         figure_of_merit: The figure of merit to be used for compilation. Defaults to "expected_fidelity".
         tracer_output_path: If provided, enables compiler tracing and exports the JSON log to this path/directory.
+        pass_timeout: Maximum duration in seconds for one compilation pass.
+            Defaults to None, which disables pass timeouts.
 
     Returns:
         A tuple containing the compiled quantum circuit, the compilation information, and the name of the device used for compilation.
+
+    Raises:
+        ValueError: If ``pass_timeout`` is not positive.
     """
     predicted_device = predict_device_for_figure_of_merit(qc, figure_of_merit=figure_of_merit)
     res = rl_compile(
-        qc, device=predicted_device, figure_of_merit=figure_of_merit, tracer_output_path=tracer_output_path
+        qc,
+        device=predicted_device,
+        figure_of_merit=figure_of_merit,
+        tracer_output_path=tracer_output_path,
+        pass_timeout=pass_timeout,
     )
     return *res, predicted_device

--- a/src/mqt/predictor/rl/actions/qiskit_actions.py
+++ b/src/mqt/predictor/rl/actions/qiskit_actions.py
@@ -81,7 +81,7 @@ from mqt.predictor.rl.actions.base import (
 )
 
 if TYPE_CHECKING:
-    from collections.abc import Callable
+    from collections.abc import Callable, Sequence
 
     from qiskit import QuantumCircuit
     from qiskit.passmanager import PropertySet
@@ -524,6 +524,13 @@ def _seed_randomized_passes(passes: list[Task], seed: int) -> None:
             transpiler_pass.trials = 1
 
 
+def _set_native_pass_time_limits(passes: Sequence[Task], pass_timeout: float | None) -> None:
+    """Configure native deadlines for Qiskit passes that support them."""
+    for transpiler_pass in passes:
+        if isinstance(transpiler_pass, (VF2Layout, VF2PostLayout)):
+            transpiler_pass.time_limit = pass_timeout
+
+
 def run_qiskit_action(
     action: Action,
     circuit: QuantumCircuit,
@@ -531,6 +538,7 @@ def run_qiskit_action(
     layout: TranspileLayout | None,
     input_qubit_count: int | None = None,
     seed: int | None = None,
+    pass_timeout: float | None = None,
 ) -> tuple[QuantumCircuit, TranspileLayout | None]:
     """Apply a Qiskit action and return the updated circuit and layout metadata."""
     # Build the concrete Qiskit pass list for given action.
@@ -542,6 +550,8 @@ def run_qiskit_action(
         passes = factory(device)
     else:
         passes = cast("list[Task]", action.transpile_pass)
+
+    _set_native_pass_time_limits(passes, pass_timeout)
 
     if seed is not None:
         _seed_randomized_passes(passes, seed)

--- a/src/mqt/predictor/rl/actions/qiskit_actions.py
+++ b/src/mqt/predictor/rl/actions/qiskit_actions.py
@@ -10,7 +10,9 @@
 
 from __future__ import annotations
 
+import atexit
 import logging
+import multiprocessing
 from functools import cache
 from importlib import import_module
 from typing import TYPE_CHECKING, Any, cast
@@ -82,6 +84,7 @@ from mqt.predictor.rl.actions.base import (
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Sequence
+    from multiprocessing.pool import Pool
 
     from qiskit import QuantumCircuit
     from qiskit.passmanager import PropertySet
@@ -91,6 +94,8 @@ if TYPE_CHECKING:
     from mqt.predictor.rl.actions.base import Action
 
 logger = logging.getLogger("mqt-predictor")
+_QISKIT_TIMEOUT_POOL: Pool | None = None
+_VF2_ACTION_NAMES = frozenset({"VF2Layout", "VF2PostLayout"})
 
 _AI_ROUTING_ACTION_NAMES = frozenset({"AIRouting", "AIRouting_opt"})
 
@@ -531,7 +536,7 @@ def _set_native_pass_time_limits(passes: Sequence[Task], pass_timeout: float | N
             transpiler_pass.time_limit = pass_timeout
 
 
-def run_qiskit_action(
+def _run_qiskit_action(
     action: Action,
     circuit: QuantumCircuit,
     device: Target,
@@ -578,6 +583,68 @@ def run_qiskit_action(
         # Custom "unitary" gates can not be processed further by other passes
         altered_qc = altered_qc.decompose(gates_to_decompose="unitary")
     return altered_qc, layout
+
+
+def _run_registered_vf2_action(
+    action_name: str,
+    circuit: QuantumCircuit,
+    device: Target,
+    layout: TranspileLayout | None,
+    input_qubit_count: int | None,
+    seed: int | None,
+    pass_timeout: float,
+) -> tuple[QuantumCircuit, TranspileLayout | None]:
+    if action_name == "VF2Layout":
+        action = next(action for action in qiskit_layout_actions() if action.name == action_name)
+    else:
+        action = qiskit_final_optimization_action()
+    return _run_qiskit_action(action, circuit, device, layout, input_qubit_count, seed, pass_timeout)
+
+
+def _close_qiskit_timeout_pool() -> None:
+    global _QISKIT_TIMEOUT_POOL  # ruff: ignore[global-statement]
+    if _QISKIT_TIMEOUT_POOL is not None:
+        _QISKIT_TIMEOUT_POOL.terminate()
+        _QISKIT_TIMEOUT_POOL.join()
+        _QISKIT_TIMEOUT_POOL = None
+
+
+def _get_qiskit_timeout_pool() -> Pool:
+    global _QISKIT_TIMEOUT_POOL  # ruff: ignore[global-statement]
+    if _QISKIT_TIMEOUT_POOL is None:
+        _QISKIT_TIMEOUT_POOL = multiprocessing.get_context("forkserver").Pool(processes=1)
+    return _QISKIT_TIMEOUT_POOL
+
+
+atexit.register(_close_qiskit_timeout_pool)
+
+
+def run_qiskit_action(
+    action: Action,
+    circuit: QuantumCircuit,
+    device: Target,
+    layout: TranspileLayout | None,
+    input_qubit_count: int | None = None,
+    seed: int | None = None,
+    pass_timeout: float | None = None,
+) -> tuple[QuantumCircuit, TranspileLayout | None]:
+    """Apply a Qiskit action and return the updated circuit and layout metadata."""
+    if pass_timeout is None or action.name not in _VF2_ACTION_NAMES:
+        return _run_qiskit_action(action, circuit, device, layout, input_qubit_count, seed, pass_timeout)
+
+    try:
+        return (
+            _get_qiskit_timeout_pool()
+            .apply_async(
+                _run_registered_vf2_action,
+                (action.name, circuit, device, layout, input_qubit_count, seed, pass_timeout),
+            )
+            .get(timeout=pass_timeout)
+        )
+    except (multiprocessing.TimeoutError, TimeoutError) as error:
+        _close_qiskit_timeout_pool()
+        msg = f"Compilation pass exceeded the timeout of {pass_timeout:g} seconds."
+        raise TimeoutError(msg) from error
 
 
 def is_qiskit_action_available(action: Action, device: Target) -> bool:

--- a/src/mqt/predictor/rl/actions/qiskit_actions.py
+++ b/src/mqt/predictor/rl/actions/qiskit_actions.py
@@ -612,7 +612,8 @@ def _close_qiskit_timeout_pool() -> None:
 def _get_qiskit_timeout_pool() -> Pool:
     global _QISKIT_TIMEOUT_POOL  # ruff: ignore[global-statement]
     if _QISKIT_TIMEOUT_POOL is None:
-        _QISKIT_TIMEOUT_POOL = multiprocessing.get_context("forkserver").Pool(processes=1)
+        start_method = "forkserver" if "forkserver" in multiprocessing.get_all_start_methods() else "spawn"
+        _QISKIT_TIMEOUT_POOL = multiprocessing.get_context(start_method).Pool(processes=1)
     return _QISKIT_TIMEOUT_POOL
 
 

--- a/src/mqt/predictor/rl/actions/tket_actions.py
+++ b/src/mqt/predictor/rl/actions/tket_actions.py
@@ -14,6 +14,7 @@ import logging
 import operator
 from collections import defaultdict
 from functools import cache
+from math import ceil
 from typing import TYPE_CHECKING, cast
 
 from pytket import Qubit
@@ -46,6 +47,7 @@ if TYPE_CHECKING:
     from mqt.predictor.rl.actions.base import Action
 
 logger = logging.getLogger("mqt-predictor")
+_TKET_MAX_TIMEOUT_MS = 2**32 - 1
 
 
 class PreProcessTKETRoutingAfterQiskitLayout:
@@ -90,7 +92,23 @@ def _prepare_noise_data(device: Target) -> tuple[dict[Node, float], dict[tuple[N
     return node_errors, link_errors, readout_errors
 
 
-def _noise_aware_placement(device: Target) -> list[Placement]:
+def _placement_timeout_ms(pass_timeout: float | None) -> int:
+    if pass_timeout is None:
+        return _TKET_MAX_TIMEOUT_MS
+    return min(_TKET_MAX_TIMEOUT_MS, max(1, ceil(pass_timeout * 1000)))
+
+
+def _graph_placement(device: Target, pass_timeout: float | None = None) -> list[Placement]:
+    return [
+        GraphPlacement(
+            Architecture(list(device.build_coupling_map())),
+            timeout=_placement_timeout_ms(pass_timeout),
+            maximum_matches=5000,
+        )
+    ]
+
+
+def _noise_aware_placement(device: Target, pass_timeout: float | None = None) -> list[Placement]:
     node_errors, link_errors, readout_errors = _prepare_noise_data(device)
     return [
         NoiseAwarePlacement(
@@ -98,7 +116,7 @@ def _noise_aware_placement(device: Target) -> list[Placement]:
             node_errors=node_errors,
             link_errors=link_errors,
             readout_errors=readout_errors,
-            timeout=5000,
+            timeout=_placement_timeout_ms(pass_timeout),
             maximum_matches=5000,
         )
     ]
@@ -204,13 +222,7 @@ def tket_layout_actions() -> list[Action]:
             "GraphPlacement",
             CompilationOrigin.TKET,
             PassType.LAYOUT,
-            transpile_pass=lambda device: [
-                GraphPlacement(
-                    Architecture(list(device.build_coupling_map())),
-                    timeout=5000,
-                    maximum_matches=5000,
-                )
-            ],
+            transpile_pass=_graph_placement,
         ),
         DeferredDeviceAction(
             "NoiseAwarePlacement",
@@ -258,15 +270,23 @@ def run_tket_action(
     circuit: QuantumCircuit,
     device: Target,
     layout: TranspileLayout | None,
+    pass_timeout: float | None = None,
 ) -> tuple[QuantumCircuit, TranspileLayout | None]:
     """Apply a TKET action and return the updated circuit and layout metadata."""
     tket_qc = qiskit_to_tk(circuit, preserve_param_uuid=True)
     if callable(action.transpile_pass):
-        factory = cast(
-            "Callable[[Target], list[TketBasePass | PreProcessTKETRoutingAfterQiskitLayout | Placement]]",
-            action.transpile_pass,
-        )
-        passes = factory(device)
+        if action.transpile_pass in {_graph_placement, _noise_aware_placement}:
+            timeout_factory = cast(
+                "Callable[[Target, float | None], list[TketBasePass | PreProcessTKETRoutingAfterQiskitLayout | Placement]]",
+                action.transpile_pass,
+            )
+            passes = timeout_factory(device, pass_timeout)
+        else:
+            factory = cast(
+                "Callable[[Target], list[TketBasePass | PreProcessTKETRoutingAfterQiskitLayout | Placement]]",
+                action.transpile_pass,
+            )
+            passes = factory(device)
     else:
         passes = cast("list[TketBasePass | PreProcessTKETRoutingAfterQiskitLayout | Placement]", action.transpile_pass)
 

--- a/src/mqt/predictor/rl/predictor.py
+++ b/src/mqt/predictor/rl/predictor.py
@@ -72,27 +72,33 @@ class Predictor:
         self,
         qc: QuantumCircuit | str,
         tracer_output_path: str | Path | None = None,
+        pass_timeout: float | None = None,
     ) -> tuple[QuantumCircuit, list[str]]:
         """Compiles a given quantum circuit such that the given figure of merit is maximized by using the respectively trained optimized compiler.
 
         Arguments:
             qc: The quantum circuit to be compiled or the path to a qasm file containing the quantum circuit.
             tracer_output_path: Optional temporary path to export the compilation trace for this specific run.
+            pass_timeout: Maximum duration in seconds for one compilation pass.
+                Defaults to None, which disables pass timeouts.
 
         Returns:
             A tuple containing the compiled quantum circuit and the compilation information. If compilation fails, False is returned.
 
         Raises:
             RuntimeError: If an error occurs during compilation.
+            ValueError: If ``pass_timeout`` is not positive.
         """
         original_tracer_output_path = self.env.tracer_output_path
         original_seed_qiskit_actions = self.env.configure_qiskit_action_seeding(enabled=False)
-
-        # Temporarily override singleton if a new path is explicitly provided
-        if tracer_output_path is not None:
-            self.env.tracer_output_path = tracer_output_path
+        original_pass_timeout = self.env.pass_timeout
 
         try:
+            # Temporarily override singleton settings for this compilation.
+            if tracer_output_path is not None:
+                self.env.tracer_output_path = tracer_output_path
+            self.env.pass_timeout = pass_timeout
+
             trained_rl_model = load_model(self.model_name)
 
             obs, _ = self.env.reset(qc)
@@ -115,8 +121,8 @@ class Predictor:
             raise RuntimeError(msg)
 
         finally:
-            # Restore original singleton path
             self.env.tracer_output_path = original_tracer_output_path
+            self.env.pass_timeout = original_pass_timeout
             self.env.configure_qiskit_action_seeding(enabled=original_seed_qiskit_actions)
 
     def train_model(
@@ -125,6 +131,7 @@ class Predictor:
         verbose: int = 2,
         test: bool = False,
         seed: int | None = None,
+        pass_timeout: float | None = None,
     ) -> None:
         """Trains all models for the given reward functions and device.
 
@@ -134,6 +141,11 @@ class Predictor:
             test: Whether to train the model for testing purposes. Defaults to False.
             seed: The random seed to use for reproducible training. Set to None to use true randomness.
                 Defaults to None.
+            pass_timeout: Maximum duration in seconds for one compilation pass.
+                Defaults to None, which disables pass timeouts.
+
+        Raises:
+            ValueError: If ``pass_timeout`` is not positive.
         """
         self.env.configure_qiskit_action_seeding(enabled=seed is not None)
         if seed is not None:
@@ -151,22 +163,27 @@ class Predictor:
             batch_size = 64
             progress_bar = True
 
-        logger.debug("Start training for: " + self.figure_of_merit + " on " + self.device_name)
-        model = MaskablePPO(
-            MaskableMultiInputActorCriticPolicy,
-            self.env,
-            verbose=verbose,
-            tensorboard_log=f"./{self.model_name}",
-            gamma=0.98,
-            n_steps=n_steps,
-            batch_size=batch_size,
-            n_epochs=n_epochs,
-            seed=seed,
-        )
-        # Training Loop: In each iteration, the agent collects n_steps steps (rollout),
-        # updates the policy for n_epochs, and then repeats the process until total_timesteps steps have been taken.
-        model.learn(total_timesteps=timesteps, progress_bar=progress_bar)
-        model.save(get_path_trained_model() / self.model_name)
+        original_pass_timeout = self.env.pass_timeout
+        self.env.pass_timeout = pass_timeout
+        try:
+            logger.debug("Start training for: " + self.figure_of_merit + " on " + self.device_name)
+            model = MaskablePPO(
+                MaskableMultiInputActorCriticPolicy,
+                self.env,
+                verbose=verbose,
+                tensorboard_log=f"./{self.model_name}",
+                gamma=0.98,
+                n_steps=n_steps,
+                batch_size=batch_size,
+                n_epochs=n_epochs,
+                seed=seed,
+            )
+            # Training Loop: In each iteration, the agent collects n_steps steps (rollout),
+            # updates the policy for n_epochs, and then repeats the process until total_timesteps steps have been taken.
+            model.learn(total_timesteps=timesteps, progress_bar=progress_bar)
+            model.save(get_path_trained_model() / self.model_name)
+        finally:
+            self.env.pass_timeout = original_pass_timeout
 
 
 def load_model(model_name: str) -> MaskablePPO:
@@ -197,6 +214,7 @@ def rl_compile(
     predictor_singleton: Predictor | None = None,
     tracer_output_path: str | Path | None = None,
     mdp: MDPPolicy = "v3",
+    pass_timeout: float | None = None,
 ) -> tuple[QuantumCircuit, list[str]]:
     """Compiles a given quantum circuit to a device optimizing for the given figure of merit.
 
@@ -209,12 +227,15 @@ def rl_compile(
         mdp: The MDP transition policy used when constructing a predictor. ``v2``
             is the original strategy and ``v3`` is the default. When
             ``predictor_singleton`` is provided, its configured policy is used instead.
+        pass_timeout: Maximum duration in seconds for one compilation pass.
+            Defaults to None, which disables pass timeouts.
 
     Returns:
         A tuple containing the compiled quantum circuit and the compilation information. If compilation fails, False is returned.
 
     Raises:
-        ValueError: If figure_of_merit or device is None and predictor_singleton is also None.
+        ValueError: If figure_of_merit or device is None and predictor_singleton is also None,
+            or if ``pass_timeout`` is not positive.
     """
     if predictor_singleton is None:
         if figure_of_merit is None:
@@ -229,6 +250,8 @@ def rl_compile(
             tracer_output_path=tracer_output_path,
             mdp=mdp,
         )
-        return predictor.compile_as_predicted(qc)
+        return predictor.compile_as_predicted(qc, pass_timeout=pass_timeout)
 
-    return predictor_singleton.compile_as_predicted(qc, tracer_output_path=tracer_output_path)
+    return predictor_singleton.compile_as_predicted(
+        qc, tracer_output_path=tracer_output_path, pass_timeout=pass_timeout
+    )

--- a/src/mqt/predictor/rl/predictorenv.py
+++ b/src/mqt/predictor/rl/predictorenv.py
@@ -630,6 +630,7 @@ class PredictorEnv(Env):
                 layout=self.layout,
                 input_qubit_count=self.num_qubits_uncompiled_circuit,
                 seed=(int(self.np_random.integers(0, np.iinfo(np.int32).max)) if self._seed_qiskit_actions else None),
+                pass_timeout=self.pass_timeout,
             )
         elif action.origin == CompilationOrigin.TKET:
             altered_qc, self.layout = run_tket_action(

--- a/src/mqt/predictor/rl/predictorenv.py
+++ b/src/mqt/predictor/rl/predictorenv.py
@@ -637,6 +637,7 @@ class PredictorEnv(Env):
                 circuit=self.state,
                 device=self.device,
                 layout=self.layout,
+                pass_timeout=self.pass_timeout,
             )
         elif action.origin == CompilationOrigin.BQSKIT:
             altered_qc, self.layout = run_bqskit_action(

--- a/src/mqt/predictor/rl/predictorenv.py
+++ b/src/mqt/predictor/rl/predictorenv.py
@@ -10,14 +10,20 @@
 
 from __future__ import annotations
 
+import contextlib
 import logging
 import re
+import signal
+import threading
 import time
 import warnings
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Literal, get_args
 
 if TYPE_CHECKING:
+    from collections.abc import Iterator
+    from types import FrameType
+
     from gymnasium.spaces import Space
     from qiskit.transpiler import Layout, Target
 
@@ -60,6 +66,43 @@ MDPPolicy = Literal["v2", "v3"]
 MDP_POLICIES: frozenset[str] = frozenset(get_args(MDPPolicy))
 
 
+@contextlib.contextmanager
+def _enforce_pass_timeout(pass_timeout: float | None) -> Iterator[None]:
+    if pass_timeout is None:
+        yield
+        return
+
+    if not all(hasattr(signal, attribute) for attribute in ("SIGALRM", "ITIMER_REAL", "getitimer", "setitimer")):
+        warnings.warn("Pass timeouts are not supported on this platform.", RuntimeWarning, stacklevel=2)
+        yield
+        return
+    if threading.current_thread() is not threading.main_thread():
+        warnings.warn("Pass timeouts are only supported on the main thread.", RuntimeWarning, stacklevel=2)
+        yield
+        return
+
+    def timeout_handler(_signum: int, _frame: FrameType | None) -> None:
+        msg = f"Compilation pass exceeded the timeout of {pass_timeout:g} seconds."
+        raise TimeoutError(msg)
+
+    previous_delay, previous_interval = signal.getitimer(signal.ITIMER_REAL)
+    if 0 < previous_delay <= pass_timeout:
+        yield
+        return
+
+    previous_handler = signal.signal(signal.SIGALRM, timeout_handler)
+    start_time = time.monotonic()
+    try:
+        signal.setitimer(signal.ITIMER_REAL, pass_timeout)
+        yield
+    finally:
+        signal.setitimer(signal.ITIMER_REAL, 0)
+        signal.signal(signal.SIGALRM, previous_handler)
+        if previous_delay > 0:
+            remaining_delay = max(previous_delay - (time.monotonic() - start_time), 1e-6)
+            signal.setitimer(signal.ITIMER_REAL, remaining_delay, previous_interval)
+
+
 class PredictorEnv(Env):
     """Predictor environment for reinforcement learning."""
 
@@ -71,6 +114,7 @@ class PredictorEnv(Env):
         max_steps: int | None = None,
         tracer_output_path: str | Path | None = None,
         mdp: MDPPolicy = "v3",
+        pass_timeout: float | None = None,
     ) -> None:
         """Initializes the PredictorEnv object.
 
@@ -83,9 +127,12 @@ class PredictorEnv(Env):
             mdp: The MDP transition policy. ``v2`` is the original MQT Predictor
                 strategy. ``v3`` is the default and is permissive before layout while
                 preserving the established compilation structure afterwards.
+            pass_timeout: Maximum duration in seconds for one compilation pass.
+                Defaults to None, which disables pass timeouts.
 
         Raises:
-            ValueError: If ``mdp`` is unsupported, if the reward function is
+            ValueError: If ``mdp`` is unsupported, ``pass_timeout`` is not positive,
+                if the reward function is
                 "estimated_success_probability" and no calibration data is available
                 for the device, or if the reward function is
                 "estimated_hellinger_distance" and no trained model is available for
@@ -100,6 +147,7 @@ class PredictorEnv(Env):
         self.path_training_circuits = path_training_circuits or get_path_training_circuits()
         self.max_steps = max_steps
         self.mdp = mdp
+        self.pass_timeout = pass_timeout
 
         self.action_set = {}
         self.actions_synthesis_indices = []
@@ -208,6 +256,18 @@ class PredictorEnv(Env):
         self._seed_qiskit_actions = enabled
         return previous
 
+    @property
+    def pass_timeout(self) -> float | None:
+        """The current per-pass timeout in seconds."""
+        return self._pass_timeout
+
+    @pass_timeout.setter
+    def pass_timeout(self, pass_timeout: float | None) -> None:
+        if pass_timeout is not None and pass_timeout <= 0:
+            msg = "pass_timeout must be positive."
+            raise ValueError(msg)
+        self._pass_timeout = pass_timeout
+
     def _collect_tracer_data(
         self,
         step_index: int,
@@ -297,7 +357,8 @@ class PredictorEnv(Env):
         start_time = time.perf_counter()
         try:
             self.used_actions.append(action_name)
-            altered_qc = self.apply_action(action)
+            with _enforce_pass_timeout(self.pass_timeout):
+                altered_qc = self.apply_action(action)
             action_duration = time.perf_counter() - start_time
         except Exception as exc:  # ruff:ignore[blind-except]
             action_duration = time.perf_counter() - start_time

--- a/tests/compilation/test_integration_further_SDKs.py
+++ b/tests/compilation/test_integration_further_SDKs.py
@@ -31,6 +31,7 @@ from qiskit.transpiler.passes import (
     TrivialLayout,
 )
 
+from mqt.predictor.rl import predictorenv as predictorenv_module
 from mqt.predictor.rl.actions import CompilationOrigin, PassType, bqskit_actions, tket_actions
 from mqt.predictor.rl.predictorenv import PredictorEnv
 
@@ -126,6 +127,37 @@ def simple_circuit() -> QuantumCircuit:
 def env(target: Target) -> PredictorEnv:
     """Create a PredictorEnv for state-based invariant checking."""
     return PredictorEnv(device=target, reward_function="expected_fidelity")
+
+
+@pytest.mark.parametrize("action_name", ["GraphPlacement", "NoiseAwarePlacement"])
+@pytest.mark.parametrize(("pass_timeout", "expected_ms"), [(None, 2**32 - 1), (1.25, 1250)])
+def test_tket_placement_actions_use_pass_timeout(
+    action_name: str, pass_timeout: float | None, expected_ms: int, target: Target
+) -> None:
+    """TKET placement uses the shared timeout value and has no shorter default cutoff."""
+    action = next(action for action in tket_actions.tket_layout_actions() if action.name == action_name)
+    assert callable(action.transpile_pass)
+
+    placement = action.transpile_pass(target, pass_timeout)[0]
+
+    assert placement.to_dict()["timeout"] == expected_ms
+
+
+def test_predictor_env_forwards_pass_timeout_to_tket(
+    monkeypatch: pytest.MonkeyPatch, env: PredictorEnv, simple_circuit: QuantumCircuit
+) -> None:
+    """The environment forwards its timeout to TKET action execution."""
+    env.pass_timeout = 1.25
+    env.reset(simple_circuit)
+    action_index = next(index for index, action in env.action_set.items() if action.name == "GraphPlacement")
+
+    def fake_run_tket_action(**kwargs: object) -> tuple[QuantumCircuit, None]:
+        assert kwargs["pass_timeout"] == pytest.approx(1.25)
+        return simple_circuit, None
+
+    monkeypatch.setattr(predictorenv_module, "run_tket_action", fake_run_tket_action)
+
+    assert env.apply_action(action_index) is simple_circuit
 
 
 @pytest.mark.filterwarnings("ignore:__array__ implementation doesn't accept a copy keyword:DeprecationWarning")

--- a/tests/compilation/test_predictor_rl.py
+++ b/tests/compilation/test_predictor_rl.py
@@ -545,6 +545,25 @@ def test_qiskit_vf2_actions_use_pass_timeout(pass_timeout: float | None) -> None
     assert all(transpiler_pass.time_limit == pass_timeout for transpiler_pass in passes)
 
 
+def test_qiskit_vf2_timeout_worker() -> None:
+    """The isolated VF2 worker returns results and stops at its deadline."""
+    device = get_device("ibm_falcon_27")
+    action = next(action for action in qiskit_actions.qiskit_layout_actions() if action.name == "VF2Layout")
+    circuit = QuantumCircuit(2)
+    circuit.cx(0, 1)
+
+    try:
+        compiled, layout = qiskit_actions.run_qiskit_action(action, circuit, device, None, pass_timeout=30)
+        with pytest.raises(TimeoutError, match=re.escape("exceeded the timeout of 0.001 seconds")):
+            qiskit_actions.run_qiskit_action(action, circuit, device, None, pass_timeout=0.001)
+    finally:
+        qiskit_actions._close_qiskit_timeout_pool()  # ruff: ignore[private-member-access]
+
+    assert compiled.num_qubits == device.num_qubits
+    assert layout is not None
+    assert qiskit_actions._QISKIT_TIMEOUT_POOL is None  # ruff: ignore[private-member-access]
+
+
 def test_predictor_env_forwards_pass_timeout_to_qiskit(monkeypatch: pytest.MonkeyPatch) -> None:
     """The environment forwards its timeout to Qiskit action execution."""
     env = predictorenv_module.PredictorEnv(device=get_device("ibm_falcon_27"), pass_timeout=1.25)

--- a/tests/compilation/test_predictor_rl.py
+++ b/tests/compilation/test_predictor_rl.py
@@ -534,6 +534,33 @@ def test_seed_randomized_qiskit_passes() -> None:
         assert all(getattr(transpiler_pass, attribute) == 1 for attribute in trial_attributes)
 
 
+@pytest.mark.parametrize("pass_timeout", [None, 1.25])
+def test_qiskit_vf2_actions_use_pass_timeout(pass_timeout: float | None) -> None:
+    """Qiskit's native VF2 search uses the shared timeout value."""
+    device = get_device("ibm_falcon_27")
+    passes = [VF2Layout(target=device), VF2PostLayout(target=device)]
+
+    qiskit_actions._set_native_pass_time_limits(passes, pass_timeout)  # ruff: ignore[private-member-access]
+
+    assert all(transpiler_pass.time_limit == pass_timeout for transpiler_pass in passes)
+
+
+def test_predictor_env_forwards_pass_timeout_to_qiskit(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The environment forwards its timeout to Qiskit action execution."""
+    env = predictorenv_module.PredictorEnv(device=get_device("ibm_falcon_27"), pass_timeout=1.25)
+    circuit = QuantumCircuit(2)
+    env.reset(circuit)
+    action_index = next(index for index, action in env.action_set.items() if action.name == "VF2Layout")
+
+    def fake_run_qiskit_action(**kwargs: object) -> tuple[QuantumCircuit, None]:
+        assert kwargs["pass_timeout"] == pytest.approx(1.25)
+        return circuit, None
+
+    monkeypatch.setattr(predictorenv_module, "run_qiskit_action", fake_run_qiskit_action)
+
+    assert env.apply_action(action_index) is circuit
+
+
 def test_register_action(monkeypatch: pytest.MonkeyPatch) -> None:
     """Test the register_action function."""
     actions_registry = vars(actions_registry_module)

--- a/tests/compilation/test_predictor_rl.py
+++ b/tests/compilation/test_predictor_rl.py
@@ -99,9 +99,7 @@ def test_predictor_env_rejects_nonpositive_pass_timeout(pass_timeout: float) -> 
 @pytest.mark.skipif(not hasattr(signal, "SIGALRM"), reason="SIGALRM is unavailable")
 def test_predictor_env_truncates_timed_out_pass(monkeypatch: pytest.MonkeyPatch) -> None:
     """Test that a pass timeout truncates the current episode."""
-    env = predictorenv_module.PredictorEnv(
-        device=get_device("ibm_falcon_27"), pass_timeout=0.01, intermediate_reward=False
-    )
+    env = predictorenv_module.PredictorEnv(device=get_device("ibm_falcon_27"), pass_timeout=0.01)
     qc = QuantumCircuit(1)
     env.reset(qc)
     monkeypatch.setattr(env, "apply_action", lambda _action: time.sleep(1))

--- a/tests/compilation/test_predictor_rl.py
+++ b/tests/compilation/test_predictor_rl.py
@@ -10,12 +10,14 @@
 
 from __future__ import annotations
 
+import multiprocessing
 import re
 import signal
 import time
 from importlib import import_module
 from pathlib import Path
 from typing import TYPE_CHECKING, cast
+from unittest.mock import Mock
 
 import pytest
 from mqt.bench import BenchmarkLevel, get_benchmark
@@ -546,7 +548,7 @@ def test_qiskit_vf2_actions_use_pass_timeout(pass_timeout: float | None) -> None
 
 
 def test_qiskit_vf2_timeout_worker() -> None:
-    """The isolated VF2 worker returns results and stops at its deadline."""
+    """The isolated VF2 worker returns results."""
     device = get_device("ibm_falcon_27")
     action = next(action for action in qiskit_actions.qiskit_layout_actions() if action.name == "VF2Layout")
     circuit = QuantumCircuit(2)
@@ -554,13 +556,30 @@ def test_qiskit_vf2_timeout_worker() -> None:
 
     try:
         compiled, layout = qiskit_actions.run_qiskit_action(action, circuit, device, None, pass_timeout=30)
-        with pytest.raises(TimeoutError, match=re.escape("exceeded the timeout of 0.001 seconds")):
-            qiskit_actions.run_qiskit_action(action, circuit, device, None, pass_timeout=0.001)
     finally:
         qiskit_actions._close_qiskit_timeout_pool()  # ruff: ignore[private-member-access]
 
     assert compiled.num_qubits == device.num_qubits
     assert layout is not None
+    assert qiskit_actions._QISKIT_TIMEOUT_POOL is None  # ruff: ignore[private-member-access]
+
+
+def test_qiskit_vf2_timeout_worker_stops_at_deadline(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A VF2 deadline terminates and resets the isolated worker."""
+    result = Mock()
+    result.get.side_effect = multiprocessing.TimeoutError
+    pool = Mock()
+    pool.apply_async.return_value = result
+    monkeypatch.setattr(qiskit_actions, "_QISKIT_TIMEOUT_POOL", pool)
+
+    device = get_device("ibm_falcon_27")
+    action = next(action for action in qiskit_actions.qiskit_layout_actions() if action.name == "VF2Layout")
+    with pytest.raises(TimeoutError, match=re.escape("exceeded the timeout of 1.25 seconds")):
+        qiskit_actions.run_qiskit_action(action, QuantumCircuit(2), device, None, pass_timeout=1.25)
+
+    result.get.assert_called_once_with(timeout=1.25)
+    pool.terminate.assert_called_once_with()
+    pool.join.assert_called_once_with()
     assert qiskit_actions._QISKIT_TIMEOUT_POOL is None  # ruff: ignore[private-member-access]
 
 

--- a/tests/compilation/test_predictor_rl.py
+++ b/tests/compilation/test_predictor_rl.py
@@ -164,8 +164,7 @@ def test_inference_uses_temporary_pass_timeout(monkeypatch: pytest.MonkeyPatch) 
         predictor.env.state = qc
         return {}, 0, True, False, {}
 
-    def fake_reset(_qc: QuantumCircuit | str, seed: int) -> tuple[dict[str, object], dict[str, object]]:
-        assert seed == 0
+    def fake_reset(_qc: QuantumCircuit | str) -> tuple[dict[str, object], dict[str, object]]:
         predictor.env.error_occurred = False
         return {}, {}
 

--- a/tests/compilation/test_predictor_rl.py
+++ b/tests/compilation/test_predictor_rl.py
@@ -11,6 +11,9 @@
 from __future__ import annotations
 
 import re
+import signal
+import time
+from importlib import import_module
 from pathlib import Path
 from typing import TYPE_CHECKING, cast
 
@@ -84,6 +87,124 @@ def test_predictor_env_rejects_unsupported_mdp() -> None:
 
     with pytest.raises(ValueError, match=re.escape("Unsupported MDP policy: unsupported.")):
         predictorenv_module.PredictorEnv(device=get_device("ibm_falcon_27"), mdp=invalid_mdp)
+
+
+@pytest.mark.parametrize("pass_timeout", [0, -1])
+def test_predictor_env_rejects_nonpositive_pass_timeout(pass_timeout: float) -> None:
+    """Test that pass timeouts must be positive when enabled."""
+    with pytest.raises(ValueError, match=re.escape("pass_timeout must be positive.")):
+        predictorenv_module.PredictorEnv(device=get_device("ibm_falcon_27"), pass_timeout=pass_timeout)
+
+
+@pytest.mark.skipif(not hasattr(signal, "SIGALRM"), reason="SIGALRM is unavailable")
+def test_predictor_env_truncates_timed_out_pass(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Test that a pass timeout truncates the current episode."""
+    env = predictorenv_module.PredictorEnv(
+        device=get_device("ibm_falcon_27"), pass_timeout=0.01, intermediate_reward=False
+    )
+    qc = QuantumCircuit(1)
+    env.reset(qc)
+    monkeypatch.setattr(env, "apply_action", lambda _action: time.sleep(1))
+
+    _, reward_val, terminated, truncated, info = env.step(env.actions_opt_indices[0])
+
+    assert reward_val == 0
+    assert not terminated
+    assert truncated
+    assert info == {
+        "Truncated because of error": "TimeoutError: Compilation pass exceeded the timeout of 0.01 seconds."
+    }
+
+
+def test_training_uses_temporary_pass_timeout(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Test that training applies and restores its pass timeout."""
+    observed_timeouts: list[float | None] = []
+
+    class FakeModel:
+        """Minimal MaskablePPO replacement that records the environment timeout."""
+
+        def __init__(
+            self,
+            _policy: object,
+            env: predictorenv_module.PredictorEnv,
+            **_kwargs: object,
+        ) -> None:
+            self.env = env
+
+        def learn(self, *, total_timesteps: int, progress_bar: bool) -> None:
+            assert total_timesteps == 2
+            assert not progress_bar
+            observed_timeouts.append(self.env.pass_timeout)
+
+        def save(self, _path: Path) -> None:
+            pass
+
+    monkeypatch.setattr(predictor_module, "MaskablePPO", FakeModel)
+    predictor = Predictor(figure_of_merit="expected_fidelity", device=get_device("ibm_falcon_27"))
+
+    predictor.train_model(timesteps=2, test=True, pass_timeout=2)
+
+    assert observed_timeouts == [2]
+    assert predictor.env.pass_timeout is None
+
+
+def test_inference_uses_temporary_pass_timeout(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Test that inference applies and restores its independent pass timeout."""
+    observed_timeouts: list[float | None] = []
+    qc = QuantumCircuit(1)
+    predictor = Predictor(figure_of_merit="expected_fidelity", device=get_device("ibm_falcon_27"))
+
+    class FakeModel:
+        """Minimal trained model replacement."""
+
+        def predict(self, _obs: object, *, action_masks: object) -> tuple[int, None]:
+            assert action_masks == []
+            return predictor.env.actions_opt_indices[0], None
+
+    def fake_step(_action: int) -> tuple[dict[str, object], float, bool, bool, dict[str, object]]:
+        observed_timeouts.append(predictor.env.pass_timeout)
+        predictor.env.state = qc
+        return {}, 0, True, False, {}
+
+    def fake_reset(_qc: QuantumCircuit | str, seed: int) -> tuple[dict[str, object], dict[str, object]]:
+        assert seed == 0
+        predictor.env.error_occurred = False
+        return {}, {}
+
+    monkeypatch.setattr(predictor_module, "load_model", lambda _model_name: FakeModel())
+    monkeypatch.setattr(predictor_module, "get_action_masks", lambda _env: [])
+    monkeypatch.setattr(predictor.env, "reset", fake_reset)
+    monkeypatch.setattr(predictor.env, "step", fake_step)
+
+    compiled_qc, _passes = predictor.compile_as_predicted(qc, pass_timeout=0.5)
+
+    assert compiled_qc is qc
+    assert observed_timeouts == [0.5]
+    assert predictor.env.pass_timeout is None
+
+
+def test_qcompile_forwards_inference_pass_timeout(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Test that the top-level inference API forwards its pass timeout."""
+    qcompile_module = import_module("mqt.predictor.qcompile")
+    device = get_device("ibm_falcon_27")
+    qc = QuantumCircuit(1)
+
+    def fake_predict_device(_qc: QuantumCircuit, figure_of_merit: str) -> Target:
+        assert figure_of_merit == "expected_fidelity"
+        return device
+
+    def fake_rl_compile(circuit: QuantumCircuit, **kwargs: object) -> tuple[QuantumCircuit, list[str]]:
+        assert kwargs["pass_timeout"] == 3
+        return circuit, []
+
+    monkeypatch.setattr(qcompile_module, "predict_device_for_figure_of_merit", fake_predict_device)
+    monkeypatch.setattr(qcompile_module, "rl_compile", fake_rl_compile)
+
+    compiled_qc, compilation_info, selected_device = qcompile_module.qcompile(qc, pass_timeout=3)
+
+    assert compiled_qc is qc
+    assert compilation_info == []
+    assert selected_device is device
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
🤖 *AI text below* 🤖

## Description

Adds an opt-in timeout for individual RL compilation passes during training and inference.

`pass_timeout` is exposed through the existing entry points and remains disabled by default. Every compilation action receives the same user-provided value. A timeout truncates through the existing action-error path, and per-call settings are restored so singleton predictors do not leak timeout state.

The general watchdog uses POSIX real-time signals on the main thread. Qiskit's VF2 searches additionally run in an isolated worker with a hard deadline, and the same value is forwarded to Qiskit's and TKET's native search limits. Platforms or worker threads without POSIX signal support warn and continue without the general watchdog.

Reward policy is intentionally owned by the following reward PR.

This is position 7 of the stack. It depends on #797 and is followed by #799. No new package dependencies are introduced.

Rebased onto #797's current seeded-inference API; timeout overrides preserve the seed and deterministic-prediction settings. The affected test doubles were updated to match that API. All 79 local compilation tests and full lint pass. CI, docs, and patch coverage pass on the updated head.

Part of #664

## Checklist

- [x] The pull request only contains commits that are focused and relevant to this change.
- [x] I have added appropriate tests that cover the new/changed functionality.
- [x] I have updated the documentation to reflect these changes.
- [x] I have added entries to the changelog for any noteworthy additions, changes, fixes, or removals.
- [x] I have added migration instructions to the upgrade guide (if needed).
- [x] The changes follow the project's style guidelines and introduce no new warnings.
- [x] The changes are fully tested and pass the CI checks.
- [ ] I have reviewed my own code changes.

**If PR contains AI-assisted content:**

- [x] Any agent that created, edited, or submitted GitHub content was explicitly authorized for that scope, as required by our [AI Usage Guidelines](https://github.com/munich-quantum-toolkit/predictor/blob/main/docs/ai_usage.md).
- [x] Every agent-authored or agent-edited public text body begins with the visible disclosure `🤖 *AI text below* 🤖` (titles are exempt).
- [x] I have disclosed AI assistance in the PR description.
- [ ] I confirm that I have personally reviewed and understood all AI-generated content, and accept full responsibility for it.
